### PR TITLE
Fixed simulation Shut RT button

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
@@ -200,9 +200,10 @@ namespace ControlRoomApplication.Controllers
         public override bool RequestStopAsyncAcceptingClientsAndJoin() {
             MCU.RequestStopAsyncAcceptingClientsAndJoin();
             keep_modbus_server_alive = false;
-            try {
-                PLCTCPListener.Stop();
+            try
+            {
                 PLC_Modbusserver.Dispose();
+                PLCTCPListener.Stop();
                 ClientManagmentThread.Join();
             } catch (Exception e) {
                 if ((e is ThreadStateException) || (e is ThreadStartException)) {

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -305,9 +305,8 @@ namespace ControlRoomApplication.Main
                     logger.Info("ERROR killing RT controller at index " + i.ToString());
                 }
 
-                ProgramRTControllerList[0].RadioTelescope.SpectraCyberController.BringDown();
-                ProgramRTControllerList[0].RadioTelescope.PLCDriver.Bring_down();
-                ProgramPLCDriverList[0].RequestStopAsyncAcceptingClientsAndJoin();
+                ProgramRTControllerList[i].RadioTelescope.SpectraCyberController.BringDown();
+                ProgramRTControllerList[i].RadioTelescope.PLCDriver.Bring_down();
             }
 
             // End logging

--- a/ControlRoomApplication/ControlRoomApplication/Simulators/Hardware/PLC_MCU/Simulation_control_pannel.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Simulators/Hardware/PLC_MCU/Simulation_control_pannel.cs
@@ -81,14 +81,15 @@ namespace ControlRoomApplication.Simulators.Hardware.PLC_MCU {
 
             }
         }
-        public void Bring_down() {
+        public void Bring_down()
+        {
             runsimulator = false;
+            MCU_Modbusserver.Dispose();
             PLC_emulator_thread.Join();
             PLCTCPClient.Dispose();
             PLCModbusMaster.Dispose();
             MCU_emulator_thread.Join();
             MCU_TCPListener.Stop();
-            MCU_Modbusserver.Dispose();
         }
 
         private void Run_PLC_emulator_thread() {


### PR DESCRIPTION
Some processes were being terminated in the wrong order. All child
processes must be terminated before the parent processes.

Issue #207