### PR TITLE
Fixed appointment crashing

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
@@ -534,6 +534,9 @@ namespace ControlRoomApplication.Controllers
             Stopwatch stopWatch = new Stopwatch();
             stopWatch.Start();
 
+            // temporarily set spectracyber mode to continuum
+            Parent.SpectraCyberController.SetSpectraCyberModeType(SpectraCyberModeTypeEnum.CONTINUUM);
+
             // read data
             SpectraCyberResponse response = Parent.SpectraCyberController.DoSpectraCyberScan();
 
@@ -558,6 +561,9 @@ namespace ControlRoomApplication.Controllers
 
             // check against weather station reading
             double weatherStationTemp = Parent.WeatherStation.GetOutsideTemp();
+
+            // Set SpectraCyber mode back to UNKNOWN
+            Parent.SpectraCyberController.SetSpectraCyberModeType(SpectraCyberModeTypeEnum.UNKNOWN);
 
             // return true if working correctly, false if not
             if (Math.Abs(weatherStationTemp - temperature) < MiscellaneousConstants.THERMAL_CALIBRATION_OFFSET)

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -417,11 +417,11 @@ namespace ControlRoomApplication.Main
         {
             switch (comboBox1.SelectedIndex)
             {
-                case 1:
+                case 0:
                     logger.Info("Building SpectraCyber");
                     return new SpectraCyberController(new SpectraCyber());
 
-                case 2:
+                case 1:
                 default:
                     logger.Info("Building SpectraCyberSimulator");
                     return new SpectraCyberSimulatorController(new SpectraCyberSimulator());


### PR DESCRIPTION
During thermal calibration, the SpectraCyberMode was not set before
beginning a scan. To rectify this, I temporarily set one and then set it
back.

Issue #222