### PR TITLE
Speed Calculation Hotfix

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
@@ -654,7 +654,7 @@ namespace ControlRoomApplication.Main
         private void subJogButton_Down( object sender , MouseEventArgs e ) {
             if (Validator.ValidateSpeedTextOnly(speedTextBox.Text))
             {
-                double speed = Convert.ToDouble(speedTextBox.Text)/10;
+                double speed = Convert.ToDouble(speedTextBox.Text);
                 if (Validator.ValidateSpeed(speed))
                 {
                     logger.Info("Jog PosButton MouseDown");
@@ -686,7 +686,7 @@ namespace ControlRoomApplication.Main
         {
             if (Validator.ValidateSpeedTextOnly(speedTextBox.Text))
             {
-                double speed = Convert.ToDouble(speedTextBox.Text) / 10;
+                double speed = Convert.ToDouble(speedTextBox.Text);
                
                 if (Validator.ValidateSpeed(speed))
                 {
@@ -776,7 +776,7 @@ namespace ControlRoomApplication.Main
         private void plusElaButton_Down(object sender, MouseEventArgs e ){
             if (Validator.ValidateSpeedTextOnly(speedTextBox.Text))
             {
-                double speed = Convert.ToDouble(speedTextBox.Text) / 10;
+                double speed = Convert.ToDouble(speedTextBox.Text);
                 if (Validator.ValidateSpeed(speed))
                 {
 
@@ -808,7 +808,7 @@ namespace ControlRoomApplication.Main
         private void subElaButton_Down(object sender, MouseEventArgs e ){
             if (Validator.ValidateSpeedTextOnly(speedTextBox.Text))
             {
-                double speed = Convert.ToDouble(speedTextBox.Text) / 10;
+                double speed = Convert.ToDouble(speedTextBox.Text);
                 if (Validator.ValidateSpeed(speed))
                 {
 


### PR DESCRIPTION
When retrieving speed from the SpeedSliderTextBox, the value was being divided by 10 in two places, leading to actual values that were 1/10th of the expected values.
This caused the telescope to move extremely slowly during testing.