### PR TITLE
WeatherThreshold NullPointerException Hotfix

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
@@ -934,8 +934,9 @@ namespace ControlRoomApplication.Database
                 if (threshold == null)
                 {
                     logger.Info(Utilities.GetTimeStamp() + ": The WeatherThreshold data could not be found. Creating a new one with default values...");
-                    // default values of 0 windSpeed and 2 hours for snow dump time
+                    // default values of 0 windSpeed and 2 hours for snow dump time. If the table is empty, add it
                     threshold = new WeatherThreshold(0, 120);
+                    AddWeatherThreshold(threshold);
                 }
                 return threshold;
                

--- a/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
@@ -929,17 +929,15 @@ namespace ControlRoomApplication.Database
             using (RTDbContext Context = InitializeDatabaseContext())
             {
                 var threshold = Context.WeatherThreshold.FirstOrDefault();
-               
 
-                if(threshold == null)
+
+                if (threshold == null)
                 {
-                    logger.Info(Utilities.GetTimeStamp() + ": The WeatherThreshold data could not be found.");
-                    return null;
+                    logger.Info(Utilities.GetTimeStamp() + ": The WeatherThreshold data could not be found. Creating a new one with default values...");
+                    // default values of 0 windSpeed and 2 hours for snow dump time
+                    threshold = new WeatherThreshold(0, 120);
                 }
-                else
-                {
-                    return threshold;
-                }
+                return threshold;
                
             }
             


### PR DESCRIPTION
Fixed the FetchWeatherThreshold() database operations method not handling the case where the WeatherThreshold was null (if the table was empty)