### PR TITLE
Fix sensor network reboot routine

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/ControlRoomApplication.csproj
+++ b/ControlRoomApplication/ControlRoomApplication/ControlRoomApplication.csproj
@@ -322,6 +322,7 @@
     <Compile Include="GUI\DiagnosticsForm.Designer.cs">
       <DependentUpon>DiagnosticsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\DropDownEnums\SensorNetworkDropdown.cs" />
     <Compile Include="GUI\EditTestForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorNetworkServer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorNetworkServer.cs
@@ -162,7 +162,7 @@ namespace ControlRoomApplication.Controllers.SensorNetwork
         /// This starts the SensorMonitoringRoutine. Calling this will immediately begin initialization.
         /// </summary>
         /// <returns>If started successfully, return true. Else, return false.</returns>
-        public void StartSensorMonitoringRoutine()
+        public void StartSensorMonitoringRoutine(bool rebooting = false)
         {
             Server.Start();
             CurrentlyRunning = true;
@@ -171,7 +171,7 @@ namespace ControlRoomApplication.Controllers.SensorNetwork
             Timeout.Start();
             SensorMonitoringThread.Start();
 
-            if (SimulationSensorNetwork != null)
+            if (SimulationSensorNetwork != null && !rebooting)
             {
                 SimulationSensorNetwork.StartSimulationSensorNetwork();
             }
@@ -202,16 +202,16 @@ namespace ControlRoomApplication.Controllers.SensorNetwork
             { // We want to keep using the timer if we are rebooting, not destroy it.
                 Status = SensorNetworkStatusEnum.None;
                 Timeout.Dispose();
+
+                if (SimulationSensorNetwork != null)
+                {
+                    SimulationSensorNetwork.EndSimulationSensorNetwork();
+                }
             }
             else
             {
                 Status = SensorNetworkStatusEnum.Rebooting;
                 SensorMonitoringThread = new Thread(() => { SensorMonitoringRoutine(); });
-            }
-
-            if (SimulationSensorNetwork != null)
-            {
-                SimulationSensorNetwork.EndSimulationSensorNetwork();
             }
         }
 
@@ -230,7 +230,7 @@ namespace ControlRoomApplication.Controllers.SensorNetwork
             // sure it REALLY times out.
             Thread.Sleep(SensorNetworkConstants.WatchDogTimeout + 50);
 
-            StartSensorMonitoringRoutine();
+            StartSensorMonitoringRoutine(true);
         }
 
         /// <summary>

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DropDownEnums/SensorNetworkDropdown.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DropDownEnums/SensorNetworkDropdown.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ControlRoomApplication.GUI.DropDownEnums
+{
+    /// <summary>
+    /// This will contain every option of the Sensor Network combo box so we can more easily tell what each thing is
+    /// </summary>
+    public enum SensorNetworkDropdown
+    {
+        /// <summary>
+        /// This gets selected if we are connecting to the production sensor network, or another simulation that is
+        /// not running within the control room.
+        /// </summary>
+        ProductionSensorNetwork,
+
+        /// <summary>
+        /// This gets selected if we are running the simulated sensor network within the control room.
+        /// </summary>
+        SimulatedSensorNetwork
+    }
+}

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -19,6 +19,7 @@ using ControlRoomApplication.Validation;
 using ControlRoomApplication.GUI.Data;
 using ControlRoomApplication.Util;
 using ControlRoomApplication.Controllers.SensorNetwork;
+using ControlRoomApplication.GUI.DropDownEnums;
 
 namespace ControlRoomApplication.Main
 {
@@ -126,7 +127,7 @@ namespace ControlRoomApplication.Main
             loopBackBox.Enabled = true;
             checkBox1.Enabled = true;
 
-            comboSensorNetworkBox.SelectedIndex = 1;
+            comboSensorNetworkBox.SelectedIndex = (int)SensorNetworkDropdown.SimulatedSensorNetwork;
             comboBox1.SelectedIndex = 1;
             comboBox2.SelectedIndex = 1;
             comboPLCType.SelectedIndex = 2;
@@ -294,7 +295,7 @@ namespace ControlRoomApplication.Main
                     }
 
                     bool isSensorNetworkServerSimulated = false;
-                    if(comboSensorNetworkBox.SelectedIndex == 1)
+                    if(comboSensorNetworkBox.SelectedIndex == (int)SensorNetworkDropdown.SimulatedSensorNetwork)
                     {
                         isSensorNetworkServerSimulated = true;
                     }
@@ -726,7 +727,7 @@ namespace ControlRoomApplication.Main
                 this.sensorNetworkServerPort.ForeColor = System.Drawing.Color.Black;
                 this.sensorNetworkClientPort.ForeColor = System.Drawing.Color.Black;
 
-                comboSensorNetworkBox.SelectedIndex = 1;
+                comboSensorNetworkBox.SelectedIndex = (int)SensorNetworkDropdown.SimulatedSensorNetwork;
 
 
                 if (LocalIPCombo.FindStringExact("127.0.0.1") == -1)
@@ -752,7 +753,7 @@ namespace ControlRoomApplication.Main
                     this.LocalIPCombo.Items.Add(IPAddress.Parse("192.168.0.70"));
                 }
                 this.LocalIPCombo.SelectedIndex = LocalIPCombo.FindStringExact("192.168.0.70");
-                comboSensorNetworkBox.SelectedIndex = 1;
+                comboSensorNetworkBox.SelectedIndex = (int)SensorNetworkDropdown.SimulatedSensorNetwork;
 
                 // SensorNetwork and Server IP/Ports
 
@@ -779,7 +780,30 @@ namespace ControlRoomApplication.Main
 
         private void comboSensorNetworkBox_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if(comboSensorNetworkBox.SelectedIndex == (int)SensorNetworkDropdown.ProductionSensorNetwork)
+            {
+                this.sensorNetworkServerIPAddress.Text = "192.168.0.10";
+                this.sensorNetworkClientIPAddress.Text = "192.168.0.197";
+                this.sensorNetworkServerIPAddress.ForeColor = System.Drawing.Color.Black;
+                this.sensorNetworkClientIPAddress.ForeColor = System.Drawing.Color.Black;
 
+                this.sensorNetworkServerPort.Text = "1600";
+                this.sensorNetworkClientPort.Text = "1680";
+                this.sensorNetworkServerPort.ForeColor = System.Drawing.Color.Black;
+                this.sensorNetworkClientPort.ForeColor = System.Drawing.Color.Black;
+            }
+            else
+            {
+                this.sensorNetworkServerIPAddress.Text = "127.0.0.1";
+                this.sensorNetworkClientIPAddress.Text = "127.0.0.1";
+                this.sensorNetworkServerIPAddress.ForeColor = System.Drawing.Color.Black;
+                this.sensorNetworkClientIPAddress.ForeColor = System.Drawing.Color.Black;
+
+                this.sensorNetworkServerPort.Text = "1600";
+                this.sensorNetworkClientPort.Text = "1680";
+                this.sensorNetworkServerPort.ForeColor = System.Drawing.Color.Black;
+                this.sensorNetworkClientPort.ForeColor = System.Drawing.Color.Black;
+            }
         }
 
         private void comboBox2_Click(object sender, EventArgs e)


### PR DESCRIPTION
This PR includes:
- Fixing sensor network reboot routine
- Sensor network dropdown on `MainForm.cs` now updates the client/server textboxes based on whether production or simulation is selected
- Enumeration for sensor network dropdown indexes