### PR TITLE
Removed redundant temperature initialization bytes

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/ControlRoomApplication.csproj
+++ b/ControlRoomApplication/ControlRoomApplication/ControlRoomApplication.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Controllers\PLCCommunication\PLCDrivers\TestPLCDriver.cs" />
     <Compile Include="Controllers\PLCCommunication\PLCEvents.cs" />
     <Compile Include="Controllers\SensorNetwork\PacketDecodingTools.cs" />
+    <Compile Include="Controllers\SensorNetwork\SensorInitializationEnum.cs" />
     <Compile Include="Controllers\SensorNetwork\SensorNetworkClient.cs" />
     <Compile Include="Controllers\SensorNetwork\SensorNetworkConstants.cs" />
     <Compile Include="Controllers\SensorNetwork\SensorNetworkServer.cs" />

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorInitializationEnum.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorInitializationEnum.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ControlRoomApplication.Controllers.SensorNetwork
+{
+    /// <summary>
+    /// Contains sensor initialization that is used to determine what sensor is at what index
+    /// in the byte array
+    /// </summary>
+    public enum SensorInitializationEnum
+    {
+        /// <summary>
+        /// Elevation temperature initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        ElevationTemp,
+
+        /// <summary>
+        /// Azimuth temperature initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        AzimuthTemp,
+        
+        /// <summary>
+        /// Elevation encoder initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        ElevationEncoder,
+
+        /// <summary>
+        /// Azimuth encoder initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        AzimuthEncoder,
+        
+        /// <summary>
+        /// Azimuth accelerometer initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        AzimuthAccelerometer,
+
+        /// <summary>
+        /// Elevation accelerometer initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        ElevationAccelerometer,
+
+        /// <summary>
+        /// Counterbalance accelerometer initialization. This corresponds to the index of this sensor in the
+        /// sensor initialization byte array.
+        /// </summary>
+        CounterbalanceAccelerometer
+    }
+}

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorNetworkConstants.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/SensorNetworkConstants.cs
@@ -42,12 +42,10 @@ namespace ControlRoomApplication.Controllers.SensorNetwork
         public const int DefaultInitializationTimeout = 10000; // in milliseconds
 
         /// <summary>
-        /// This is the total number of sensors that is a part of the Sensor Network. This is used to determine
-        /// the byte size of the initialization. The size for transit would be 9 minus the 2 redundant temperature
-        /// sensors, which is 7.
+        /// This is the total number of Sensor Network sensors that can be receiving data at a given time. 
+        /// This is used to determine the byte size of the initialization. 
         /// </summary>
-        public const int SensorNetworkSensorCount = 9;
-
+        public const int SensorNetworkSensorCount = 7;
 
         /// <summary>
         /// If we receive this ID from the sensor network, it means that everything is going well, and we are about

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/Simulation/SimulationSensorNetwork.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SensorNetwork/Simulation/SimulationSensorNetwork.cs
@@ -307,29 +307,25 @@ namespace ControlRoomApplication.Controllers.SensorNetwork.Simulation
         /// <param name="init">Sensor initialization we receive from the SensorNetworkServer's InitializationClient</param>
         private void InitializeSensors(byte[] init)
         {
-            if (init[0] == 0) ElevationTempData = null;
+            if (init[(int)SensorInitializationEnum.ElevationTemp] == 0) ElevationTempData = null;
             else ElevationTempData = new double[0];
 
-            // Skip [1] because that is a redundant temp sensor; the SensorNetworkServer should not know about the change
-
-            if (init[2] == 0) AzimuthTempData = null;
+            if (init[(int)SensorInitializationEnum.AzimuthTemp] == 0) AzimuthTempData = null;
             else AzimuthTempData = new double[0];
 
-            // Skip [3] because that is a redundant temp sensor; the SensorNetworkServer should not know about the change
-
-            if (init[4] == 0) ElevationEncoderData = null;
+            if (init[(int)SensorInitializationEnum.ElevationEncoder] == 0) ElevationEncoderData = null;
             else ElevationEncoderData = new double[0];
 
-            if (init[5] == 0) AzimuthEncoderData = null;
+            if (init[(int)SensorInitializationEnum.AzimuthEncoder] == 0) AzimuthEncoderData = null;
             else AzimuthEncoderData = new double[0];
 
-            if (init[6] == 0) AzimuthAccData = null;
+            if (init[(int)SensorInitializationEnum.AzimuthAccelerometer] == 0) AzimuthAccData = null;
             else AzimuthAccData = new RawAccelerometerData[0];
 
-            if (init[7] == 0) ElevationAccData = null;
+            if (init[(int)SensorInitializationEnum.ElevationAccelerometer] == 0) ElevationAccData = null;
             else ElevationAccData = new RawAccelerometerData[0];
 
-            if (init[8] == 0) CounterbalanceAccData = null;
+            if (init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] == 0) CounterbalanceAccData = null;
             else CounterbalanceAccData = new RawAccelerometerData[0];
         }
 

--- a/ControlRoomApplication/ControlRoomApplication/Entities/SensorNetworkConfig/SensorNetworkConfig.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Entities/SensorNetworkConfig/SensorNetworkConfig.cs
@@ -30,9 +30,7 @@ namespace ControlRoomApplication.Entities
 
             // Initialize all sensors to enabled by default
             ElevationTemp1Init = true;
-            ElevationTemp2Init = true;
             AzimuthTemp1Init = true;
-            AzimuthTemp2Init = true;
             AzimuthAccelerometerInit = true;
             ElevationAccelerometerInit = true;
             CounterbalanceAccelerometerInit = true;
@@ -52,9 +50,7 @@ namespace ControlRoomApplication.Entities
 
             // Initialize all sensors to be disabled
             ElevationTemp1Init = false;
-            ElevationTemp2Init = false;
             AzimuthTemp1Init = false;
-            AzimuthTemp2Init = false;
             AzimuthAccelerometerInit = false;
             ElevationAccelerometerInit = false;
             CounterbalanceAccelerometerInit = false;
@@ -87,15 +83,6 @@ namespace ControlRoomApplication.Entities
         public bool ElevationTemp1Init { get; set; }
 
         /// <summary>
-        /// This will tell the Sensor Network whether or not to initialize the second (redundant) elevation motor temp sensor.
-        /// We will not receive data for this sensor if it is not initialized.
-        /// true = initialize;
-        /// false = do not initialize
-        /// </summary>
-        [Column("elevation_temp_2_init")]
-        public bool ElevationTemp2Init { get; set; }
-
-        /// <summary>
         /// This will tell the Sensor Network whether or not to initialize the primary azimuth motor temp sensor.
         /// We will not receive data for this sensor if it is not initialized.
         /// true = initialize;
@@ -103,15 +90,6 @@ namespace ControlRoomApplication.Entities
         /// </summary>
         [Column("azimuth_temp_1_init")]
         public bool AzimuthTemp1Init { get; set; }
-
-        /// <summary>
-        /// This will tell the Sensor Network whether or not to initialize the second (redundant) azimuth motor temp sensor.
-        /// We will not receive data for this sensor if it is not initialized.
-        /// true = initialize;
-        /// false = do not initialize
-        /// </summary>
-        [Column("azimuth_temp_2_init")]
-        public bool AzimuthTemp2Init { get; set; }
 
         /// <summary>
         /// This will tell the Sensor Network whether or not to initialize the azimuth accelerometer.
@@ -185,9 +163,7 @@ namespace ControlRoomApplication.Entities
             else if (
                 this.TelescopeId == other.TelescopeId &&
                 this.ElevationTemp1Init == other.ElevationTemp1Init &&
-                this.ElevationTemp2Init == other.ElevationTemp2Init &&
                 this.AzimuthTemp1Init == other.AzimuthTemp1Init &&
-                this.AzimuthTemp2Init == other.AzimuthTemp2Init &&
                 this.AzimuthAccelerometerInit == other.AzimuthAccelerometerInit &&
                 this.ElevationAccelerometerInit == other.ElevationAccelerometerInit &&
                 this.CounterbalanceAccelerometerInit == other.CounterbalanceAccelerometerInit &&
@@ -216,9 +192,7 @@ namespace ControlRoomApplication.Entities
         {
             byte[] init = new byte[] {
                 ElevationTemp1Init ?                (byte)1 : (byte)0,
-                ElevationTemp2Init ?                (byte)1 : (byte)0,
                 AzimuthTemp1Init ?                  (byte)1 : (byte)0,
-                AzimuthTemp2Init ?                  (byte)1 : (byte)0,
                 ElevationEncoderInit ?              (byte)1 : (byte)0,
                 AzimuthEncoderInit ?                (byte)1 : (byte)0,
                 AzimuthAccelerometerInit ?          (byte)1 : (byte)0,

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.Designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.Designer.cs
@@ -194,9 +194,7 @@
             this.CounterbalanceAccelerometer = new System.Windows.Forms.CheckBox();
             this.ElevationAccelerometer = new System.Windows.Forms.CheckBox();
             this.AzimuthAccelerometer = new System.Windows.Forms.CheckBox();
-            this.AzimuthTemperature2 = new System.Windows.Forms.CheckBox();
             this.AzimuthTemperature1 = new System.Windows.Forms.CheckBox();
-            this.ElevationTemperature2 = new System.Windows.Forms.CheckBox();
             this.ElevationTemperature1 = new System.Windows.Forms.CheckBox();
             this.grpProximitySensors = new System.Windows.Forms.GroupBox();
             this.label4 = new System.Windows.Forms.Label();
@@ -1937,9 +1935,7 @@
             this.SensorNetworkSensorInitialization.Controls.Add(this.CounterbalanceAccelerometer);
             this.SensorNetworkSensorInitialization.Controls.Add(this.ElevationAccelerometer);
             this.SensorNetworkSensorInitialization.Controls.Add(this.AzimuthAccelerometer);
-            this.SensorNetworkSensorInitialization.Controls.Add(this.AzimuthTemperature2);
             this.SensorNetworkSensorInitialization.Controls.Add(this.AzimuthTemperature1);
-            this.SensorNetworkSensorInitialization.Controls.Add(this.ElevationTemperature2);
             this.SensorNetworkSensorInitialization.Controls.Add(this.ElevationTemperature1);
             this.SensorNetworkSensorInitialization.Location = new System.Drawing.Point(344, 210);
             this.SensorNetworkSensorInitialization.Name = "SensorNetworkSensorInitialization";
@@ -2030,7 +2026,7 @@
             // CounterbalanceAccelerometer
             // 
             this.CounterbalanceAccelerometer.AutoSize = true;
-            this.CounterbalanceAccelerometer.Location = new System.Drawing.Point(5, 164);
+            this.CounterbalanceAccelerometer.Location = new System.Drawing.Point(5, 126);
             this.CounterbalanceAccelerometer.Name = "CounterbalanceAccelerometer";
             this.CounterbalanceAccelerometer.Size = new System.Drawing.Size(172, 17);
             this.CounterbalanceAccelerometer.TabIndex = 6;
@@ -2040,7 +2036,7 @@
             // ElevationAccelerometer
             // 
             this.ElevationAccelerometer.AutoSize = true;
-            this.ElevationAccelerometer.Location = new System.Drawing.Point(5, 146);
+            this.ElevationAccelerometer.Location = new System.Drawing.Point(5, 108);
             this.ElevationAccelerometer.Name = "ElevationAccelerometer";
             this.ElevationAccelerometer.Size = new System.Drawing.Size(141, 17);
             this.ElevationAccelerometer.TabIndex = 5;
@@ -2050,51 +2046,31 @@
             // AzimuthAccelerometer
             // 
             this.AzimuthAccelerometer.AutoSize = true;
-            this.AzimuthAccelerometer.Location = new System.Drawing.Point(5, 128);
+            this.AzimuthAccelerometer.Location = new System.Drawing.Point(5, 90);
             this.AzimuthAccelerometer.Name = "AzimuthAccelerometer";
             this.AzimuthAccelerometer.Size = new System.Drawing.Size(134, 17);
             this.AzimuthAccelerometer.TabIndex = 4;
             this.AzimuthAccelerometer.Text = "Azimuth Accelerometer";
             this.AzimuthAccelerometer.UseVisualStyleBackColor = true;
             // 
-            // AzimuthTemperature2
-            // 
-            this.AzimuthTemperature2.AutoSize = true;
-            this.AzimuthTemperature2.Location = new System.Drawing.Point(5, 110);
-            this.AzimuthTemperature2.Name = "AzimuthTemperature2";
-            this.AzimuthTemperature2.Size = new System.Drawing.Size(135, 17);
-            this.AzimuthTemperature2.TabIndex = 3;
-            this.AzimuthTemperature2.Text = "Azimuth Temperature 2";
-            this.AzimuthTemperature2.UseVisualStyleBackColor = true;
-            // 
             // AzimuthTemperature1
             // 
             this.AzimuthTemperature1.AutoSize = true;
-            this.AzimuthTemperature1.Location = new System.Drawing.Point(5, 92);
+            this.AzimuthTemperature1.Location = new System.Drawing.Point(5, 73);
             this.AzimuthTemperature1.Name = "AzimuthTemperature1";
-            this.AzimuthTemperature1.Size = new System.Drawing.Size(135, 17);
+            this.AzimuthTemperature1.Size = new System.Drawing.Size(156, 17);
             this.AzimuthTemperature1.TabIndex = 2;
-            this.AzimuthTemperature1.Text = "Azimuth Temperature 1";
+            this.AzimuthTemperature1.Text = "Azimuth Motor Temperature";
             this.AzimuthTemperature1.UseVisualStyleBackColor = true;
-            // 
-            // ElevationTemperature2
-            // 
-            this.ElevationTemperature2.AutoSize = true;
-            this.ElevationTemperature2.Location = new System.Drawing.Point(5, 74);
-            this.ElevationTemperature2.Name = "ElevationTemperature2";
-            this.ElevationTemperature2.Size = new System.Drawing.Size(142, 17);
-            this.ElevationTemperature2.TabIndex = 1;
-            this.ElevationTemperature2.Text = "Elevation Temperature 2";
-            this.ElevationTemperature2.UseVisualStyleBackColor = true;
             // 
             // ElevationTemperature1
             // 
             this.ElevationTemperature1.AutoSize = true;
             this.ElevationTemperature1.Location = new System.Drawing.Point(5, 56);
             this.ElevationTemperature1.Name = "ElevationTemperature1";
-            this.ElevationTemperature1.Size = new System.Drawing.Size(142, 17);
+            this.ElevationTemperature1.Size = new System.Drawing.Size(163, 17);
             this.ElevationTemperature1.TabIndex = 0;
-            this.ElevationTemperature1.Text = "Elevation Temperature 1";
+            this.ElevationTemperature1.Text = "Elevation Motor Temperature";
             this.ElevationTemperature1.UseVisualStyleBackColor = true;
             // 
             // grpProximitySensors
@@ -2815,9 +2791,7 @@
         private System.Windows.Forms.CheckBox CounterbalanceAccelerometer;
         private System.Windows.Forms.CheckBox ElevationAccelerometer;
         private System.Windows.Forms.CheckBox AzimuthAccelerometer;
-        private System.Windows.Forms.CheckBox AzimuthTemperature2;
         private System.Windows.Forms.CheckBox AzimuthTemperature1;
-        private System.Windows.Forms.CheckBox ElevationTemperature2;
         private System.Windows.Forms.CheckBox ElevationTemperature1;
         private System.Windows.Forms.GroupBox Encoders;
         private System.Windows.Forms.Button btnElevationAbsoluteEncoder;

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
@@ -177,9 +177,7 @@ namespace ControlRoomApplication.GUI
             SensorNetworkConfig = rtController.RadioTelescope.SensorNetworkServer.InitializationClient.config;
 
             AzimuthTemperature1.Checked = SensorNetworkConfig.AzimuthTemp1Init;
-            AzimuthTemperature2.Checked = SensorNetworkConfig.AzimuthTemp2Init;
             ElevationTemperature1.Checked = SensorNetworkConfig.ElevationTemp1Init;
-            ElevationTemperature2.Checked = SensorNetworkConfig.ElevationTemp2Init;
             AzimuthAccelerometer.Checked = SensorNetworkConfig.AzimuthAccelerometerInit;
             ElevationAccelerometer.Checked = SensorNetworkConfig.ElevationAccelerometerInit;
             CounterbalanceAccelerometer.Checked = SensorNetworkConfig.CounterbalanceAccelerometerInit;
@@ -1351,9 +1349,7 @@ namespace ControlRoomApplication.GUI
             await Task.Run(() => { 
                 // First set all the checkboxes equal to the sensor network config
                 SensorNetworkConfig.AzimuthTemp1Init = AzimuthTemperature1.Checked;
-                SensorNetworkConfig.AzimuthTemp2Init = AzimuthTemperature2.Checked;
                 SensorNetworkConfig.ElevationTemp1Init = ElevationTemperature1.Checked;
-                SensorNetworkConfig.ElevationTemp2Init = ElevationTemperature2.Checked;
                 SensorNetworkConfig.AzimuthAccelerometerInit = AzimuthAccelerometer.Checked;
                 SensorNetworkConfig.ElevationAccelerometerInit = ElevationAccelerometer.Checked;
                 SensorNetworkConfig.CounterbalanceAccelerometerInit = CounterbalanceAccelerometer.Checked;

--- a/ControlRoomApplication/ControlRoomApplicationTest/DatabaseOperationsTests/DatabaseOperationsTests.cs
+++ b/ControlRoomApplication/ControlRoomApplicationTest/DatabaseOperationsTests/DatabaseOperationsTests.cs
@@ -629,9 +629,7 @@ namespace ControlRoomApplicationTest.DatabaseOperationsTests
 
             // Change values so the updated one is different
             original.ElevationTemp1Init = false;
-            original.ElevationTemp2Init = false;
             original.AzimuthTemp1Init = false;
-            original.AzimuthTemp2Init = false;
             original.ElevationAccelerometerInit = false;
             original.AzimuthAccelerometerInit = false;
             original.CounterbalanceAccelerometerInit = false;

--- a/ControlRoomApplication/ControlRoomApplicationTest/EntitiesTests/SensorNetworkConfigTest.cs
+++ b/ControlRoomApplication/ControlRoomApplicationTest/EntitiesTests/SensorNetworkConfigTest.cs
@@ -29,9 +29,7 @@ namespace ControlRoomApplicationTest.EntitiesTests
 
             // default initialization (all must default to true)
             Assert.AreEqual(config.ElevationTemp1Init, true);
-            Assert.AreEqual(config.ElevationTemp2Init, true);
             Assert.AreEqual(config.AzimuthTemp1Init, true);
-            Assert.AreEqual(config.AzimuthTemp2Init, true);
             Assert.AreEqual(config.ElevationAccelerometerInit, true);
             Assert.AreEqual(config.AzimuthAccelerometerInit, true);
             Assert.AreEqual(config.CounterbalanceAccelerometerInit, true);
@@ -52,9 +50,7 @@ namespace ControlRoomApplicationTest.EntitiesTests
             Assert.AreEqual(config.TimeoutInitialization, 0);
             
             Assert.AreEqual(config.ElevationTemp1Init, false);
-            Assert.AreEqual(config.ElevationTemp2Init, false);
             Assert.AreEqual(config.AzimuthTemp1Init, false);
-            Assert.AreEqual(config.AzimuthTemp2Init, false);
             Assert.AreEqual(config.ElevationAccelerometerInit, false);
             Assert.AreEqual(config.AzimuthAccelerometerInit, false);
             Assert.AreEqual(config.CounterbalanceAccelerometerInit, false);
@@ -97,19 +93,6 @@ namespace ControlRoomApplicationTest.EntitiesTests
         }
 
         [TestMethod]
-        public void TestEquals_ElevationTemp2InitDifferent_NotEqual()
-        {
-            int telescopeId = 5;
-
-            SensorNetworkConfig config = new SensorNetworkConfig(telescopeId);
-            SensorNetworkConfig other = new SensorNetworkConfig(telescopeId);
-
-            other.ElevationTemp2Init = false;
-
-            Assert.IsFalse(config.Equals(other));
-        }
-
-        [TestMethod]
         public void TestEquals_AzimuthTemp1InitDifferent_NotEqual()
         {
             int telescopeId = 5;
@@ -118,19 +101,6 @@ namespace ControlRoomApplicationTest.EntitiesTests
             SensorNetworkConfig other = new SensorNetworkConfig(telescopeId);
 
             other.AzimuthTemp1Init = false;
-
-            Assert.IsFalse(config.Equals(other));
-        }
-
-        [TestMethod]
-        public void TestEquals_AzimuthTemp2InitDifferent_NotEqual()
-        {
-            int telescopeId = 5;
-
-            SensorNetworkConfig config = new SensorNetworkConfig(telescopeId);
-            SensorNetworkConfig other = new SensorNetworkConfig(telescopeId);
-
-            other.AzimuthTemp2Init = false;
 
             Assert.IsFalse(config.Equals(other));
         }
@@ -243,9 +213,7 @@ namespace ControlRoomApplicationTest.EntitiesTests
             SensorNetworkConfig config = new SensorNetworkConfig(5);
 
             config.ElevationTemp1Init = false;
-            config.ElevationTemp2Init = false;
             config.AzimuthTemp1Init = false;
-            config.AzimuthTemp2Init = false;
             config.ElevationAccelerometerInit = false;
             config.AzimuthAccelerometerInit = false;
             config.CounterbalanceAccelerometerInit = false;

--- a/ControlRoomApplication/ControlRoomApplicationTest/EntityControllersTests/SensorNetworkTests/SensorNetworkClientTest.cs
+++ b/ControlRoomApplication/ControlRoomApplicationTest/EntityControllersTests/SensorNetworkTests/SensorNetworkClientTest.cs
@@ -163,9 +163,7 @@ namespace ControlRoomApplicationTest.EntityControllersTests
 
             // Flip sensor initialization bytes to 0
             client.config.ElevationTemp1Init = false;
-            client.config.ElevationTemp2Init = false;
             client.config.AzimuthTemp1Init = false;
-            client.config.AzimuthTemp2Init = false;
             client.config.AzimuthAccelerometerInit = false;
             client.config.ElevationAccelerometerInit = false;
             client.config.CounterbalanceAccelerometerInit = false;

--- a/ControlRoomApplication/ControlRoomApplicationTest/EntityControllersTests/SensorNetworkTests/Simulation/SimulationSensorNetworkTest.cs
+++ b/ControlRoomApplication/ControlRoomApplicationTest/EntityControllersTests/SensorNetworkTests/Simulation/SimulationSensorNetworkTest.cs
@@ -94,19 +94,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 1;
-            init[6] = 1;
-            init[7] = 1;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -138,19 +134,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 0;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 1;
-            init[6] = 1;
-            init[7] = 1;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -182,19 +174,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 0;
-            init[5] = 1;
-            init[6] = 1;
-            init[7] = 1;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -226,19 +214,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 0;
-            init[6] = 1;
-            init[7] = 1;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -270,19 +254,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 1;
-            init[6] = 0;
-            init[7] = 1;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -313,20 +293,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
         {
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
-            // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 1;
-            init[6] = 1;
-            init[7] = 0;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -357,20 +332,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
         {
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
-            // Create an initialization that will enable all sensors.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 1;
-            init[1] = 1;
-            init[2] = 1;
-            init[3] = 1;
-            init[4] = 1;
-            init[5] = 1;
-            init[6] = 1;
-            init[7] = 1;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 1;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -492,19 +462,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 1;
-            init[3] = 0;
-            init[4] = 0;
-            init[5] = 0;
-            init[6] = 0;
-            init[7] = 0;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 1;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -538,19 +504,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 0;
-            init[3] = 0;
-            init[4] = 1;
-            init[5] = 0;
-            init[6] = 0;
-            init[7] = 0;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -584,19 +546,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
             // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 0;
-            init[3] = 0;
-            init[4] = 0;
-            init[5] = 1;
-            init[6] = 0;
-            init[7] = 0;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 1;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -629,20 +587,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
         {
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
-            // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 0;
-            init[3] = 0;
-            init[4] = 0;
-            init[5] = 0;
-            init[6] = 1;
-            init[7] = 0;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -677,20 +630,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
         {
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
-            // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 0;
-            init[3] = 0;
-            init[4] = 0;
-            init[5] = 0;
-            init[6] = 0;
-            init[7] = 1;
-            init[8] = 0;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 1;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 0;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -725,20 +673,15 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
         {
             PrivateObject privSim = new PrivateObject(SimSensorNetwork);
 
-            // Initialize only one sensor, so that is the only sensor that gets CSV data.
-            byte[] init = new byte[9];
+            byte[] init = new byte[SensorNetworkConstants.SensorNetworkSensorCount];
 
-            // This is not in a loop so that it's easy to copy, paste and modify (and understand)
-            // for other sensors
-            init[0] = 0;
-            init[1] = 0;
-            init[2] = 0;
-            init[3] = 0;
-            init[4] = 0;
-            init[5] = 0;
-            init[6] = 0;
-            init[7] = 0;
-            init[8] = 1;
+            init[(int)SensorInitializationEnum.ElevationTemp] = 0;
+            init[(int)SensorInitializationEnum.AzimuthTemp] = 0;
+            init[(int)SensorInitializationEnum.ElevationEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthEncoder] = 0;
+            init[(int)SensorInitializationEnum.AzimuthAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.ElevationAccelerometer] = 0;
+            init[(int)SensorInitializationEnum.CounterbalanceAccelerometer] = 1;
 
             privSim.Invoke("InitializeSensors", init);
 
@@ -838,7 +781,7 @@ namespace ControlRoomApplicationTest.EntityControllersTests.SensorNetworkTests.S
             });
             expectConfThread.Start();
 
-            byte[] expected = Encoding.ASCII.GetBytes("123456789");
+            byte[] expected = Encoding.ASCII.GetBytes("1234567");
             byte[] result = new byte[expected.Length];
 
             // This method has a blocking method, so we must run it in a separate thread


### PR DESCRIPTION
This involved a lot of refactoring of code in the simulation sensor
network because I hardcoded certain values that should have been in an
enum. Those values are now in an enum, so if sensors need removed down
the road, this problem should not arise again.

Issue #322