### PR TITLE
Removed functionality that was clearing PLC IP/Port on focus

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.Designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.Designer.cs
@@ -138,7 +138,6 @@
             this.txtPLCPort.Size = new System.Drawing.Size(118, 29);
             this.txtPLCPort.TabIndex = 5;
             this.txtPLCPort.TextChanged += new System.EventHandler(this.txtPLCPort_TextChanged);
-            this.txtPLCPort.GotFocus += new System.EventHandler(this.textBox1_Focus);
             // 
             // comboBox1
             // 
@@ -168,7 +167,6 @@
             this.txtPLCIP.Size = new System.Drawing.Size(118, 29);
             this.txtPLCIP.TabIndex = 4;
             this.txtPLCIP.TextChanged += new System.EventHandler(this.txtPLCIP_TextChanged);
-            this.txtPLCIP.GotFocus += new System.EventHandler(this.textBox2_Focus);
             // 
             // comboBox2
             // 

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -464,30 +464,6 @@ namespace ControlRoomApplication.Main
             }
 
         }
-        private void textBox3_Focus(object sender, EventArgs e)
-        {
-            logger.Info(Utilities.GetTimeStamp() + ": textBox3_Focus Event");
-            txtWSCOMPort.Text = "";
-        }
-
-
-        /// <summary>
-        /// Erases the current text in the plc port textbox. 
-        /// </summary>
-        private void textBox2_Focus(object sender, EventArgs e)
-        {
-            logger.Info(Utilities.GetTimeStamp() + ": textBox2_Focus Event");
-            txtPLCIP.Text = "";
-        }
-
-        /// <summary>
-        /// Erases the current text in the plc IP address textbox.
-        /// </summary>
-        private void textBox1_Focus(object sender, EventArgs e)
-        {
-            logger.Info(Utilities.GetTimeStamp() + ": textBox1_Focus Event");
-            txtPLCPort.Text = "";
-        }
 
         /// <summary>
         /// Generates a diagnostic form for whichever telescope configuration is chosen


### PR DESCRIPTION
It is now consistent with the rest of the form, and will not autoclear when you click in the box.