### PR TITLE
Hz to kHz

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
@@ -968,7 +968,7 @@ namespace ControlRoomApplication.Main
                 Utilities.WriteToGUIFromThread<FreeControlForm>(this, () =>
                 {
                    this.frequencyToolTip.Show("Frequency must be a non-negative\n " +
-                "value, in hertz (>= 0 Hz)", lblFrequency);
+                "value, in kilohertz (>= 0 kHz)", lblFrequency);
                 });
                 
             }

--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
@@ -912,9 +912,9 @@ namespace ControlRoomApplication.Main
             this.lblFrequency.Location = new System.Drawing.Point(155, 0);
             this.lblFrequency.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblFrequency.Name = "lblFrequency";
-            this.lblFrequency.Size = new System.Drawing.Size(79, 13);
+            this.lblFrequency.Size = new System.Drawing.Size(85, 13);
             this.lblFrequency.TabIndex = 34;
-            this.lblFrequency.Text = "Frequency (Hz)";
+            this.lblFrequency.Text = "Frequency (kHz)";
             // 
             // label9
             // 


### PR DESCRIPTION
I checked these changes with Todd, and he approved the decision to change Hz to kHz. This issue was only a UI issue because further testing relieved that the input frequency was being interpreted as kHz by the SpectraCyber, but displayed as Hz on the UI.