### PR TITLE
Disable edit settings while scanning

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
@@ -885,6 +885,8 @@ namespace ControlRoomApplication.Main
                         rtController.RadioTelescope.SpectraCyberController.SetSpectraCyberIFGain(Convert.ToDouble(IFGainVal.Text));
                         break;
                 }
+            
+                finalizeSettingsButton.Enabled = false;
 
                 startScanButton.Enabled = false;
                 startScanButton.BackColor = System.Drawing.Color.DarkGray;
@@ -907,6 +909,8 @@ namespace ControlRoomApplication.Main
                 rtController.RadioTelescope.SpectraCyberController.StopScan();
                 logger.Info(Utilities.GetTimeStamp() + ": [SpectraCyberController] Scan has stopped");
             }
+
+            finalizeSettingsButton.Enabled = true;
 
             startScanButton.Enabled = true;
             startScanButton.BackColor = System.Drawing.Color.LimeGreen;


### PR DESCRIPTION
Disabling the `Finalize Settings` button was the easiest way to solve multiple issues. The original issue was editing the scan type, and pressing `Start Scan` while a scan was running would cause a crash. Another bug I found was that the scan settings could be changed without finalizing the settings, so the SpectraCyber could attempt to run with invalid fields. Another bug found was that starting a scan without stopping it first does not reset the graph when using the production SpectraCyber, which caused graphing issues. Also, starting a scan without stopping the previous one was only possible because the `Start Scan` button is set active whenever clicking the `Finalize Settings` button.

Disabling the `Finalize Settings` button when the `Start Scan` button is clicked and enabling it when the `Stop Scan` is clicked solves all of these issues. I ran the decision by Todd, and he also approved. 