### PR TITLE
Remove create production weather station button

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Entities/WeatherStation/WeatherStation.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Entities/WeatherStation/WeatherStation.cs
@@ -72,8 +72,7 @@ namespace ControlRoomApplication.Entities.WeatherStation
 
         Weather_Data data;
 
-
-        public WeatherStation(int currentWindSpeedScanDelayMS, int commPort = 8)
+        public WeatherStation(int currentWindSpeedScanDelayMS, int commPort = 3)
             : base(currentWindSpeedScanDelayMS)
         {
 
@@ -103,7 +102,8 @@ namespace ControlRoomApplication.Entities.WeatherStation
         {
             if (OpenCommPort_V((short)commPort, 19200) != 0)
             {
-                logger.Error(Utilities.GetTimeStamp() + ": OpenCommPort unsuccessful!");
+                    logger.Error(Utilities.GetTimeStamp() + ": OpenCommPort unsuccessful!");
+                    
                     throw new ExternalException();
             }
 

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.Designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.Designer.cs
@@ -63,7 +63,6 @@
             this.sensorNetworkServerIPAddress = new System.Windows.Forms.TextBox();
             this.txtMcuCOMPort = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
-            this.createWSButton = new System.Windows.Forms.Button();
             this.acceptSettings = new System.Windows.Forms.Button();
             this.startRTGroupbox = new System.Windows.Forms.GroupBox();
             this.helpButton = new System.Windows.Forms.Button();
@@ -85,10 +84,10 @@
             this.startButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.startButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F);
             this.startButton.ForeColor = System.Drawing.Color.Black;
-            this.startButton.Location = new System.Drawing.Point(197, 68);
-            this.startButton.Margin = new System.Windows.Forms.Padding(2);
+            this.startButton.Location = new System.Drawing.Point(263, 84);
+            this.startButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.startButton.Name = "startButton";
-            this.startButton.Size = new System.Drawing.Size(170, 40);
+            this.startButton.Size = new System.Drawing.Size(227, 49);
             this.startButton.TabIndex = 6;
             this.startButton.Text = "Start RT";
             this.startButton.UseVisualStyleBackColor = false;
@@ -102,13 +101,13 @@
             this.dataGridView1.BackgroundColor = System.Drawing.Color.Gainsboro;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.GridColor = System.Drawing.SystemColors.ActiveCaptionText;
-            this.dataGridView1.Location = new System.Drawing.Point(11, 22);
-            this.dataGridView1.Margin = new System.Windows.Forms.Padding(2);
+            this.dataGridView1.Location = new System.Drawing.Point(15, 27);
+            this.dataGridView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.AutoSizeToAllHeaders;
             this.dataGridView1.RowTemplate.Height = 24;
             this.dataGridView1.RowTemplate.ReadOnly = true;
-            this.dataGridView1.Size = new System.Drawing.Size(509, 230);
+            this.dataGridView1.Size = new System.Drawing.Size(679, 283);
             this.dataGridView1.TabIndex = 7;
             this.dataGridView1.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellContentClick);
             // 
@@ -118,10 +117,10 @@
             this.shutdownButton.BackColor = System.Drawing.Color.Red;
             this.shutdownButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.shutdownButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F);
-            this.shutdownButton.Location = new System.Drawing.Point(13, 68);
-            this.shutdownButton.Margin = new System.Windows.Forms.Padding(2);
+            this.shutdownButton.Location = new System.Drawing.Point(17, 84);
+            this.shutdownButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.shutdownButton.Name = "shutdownButton";
-            this.shutdownButton.Size = new System.Drawing.Size(170, 40);
+            this.shutdownButton.Size = new System.Drawing.Size(227, 49);
             this.shutdownButton.TabIndex = 7;
             this.shutdownButton.Text = "Shutdown RT";
             this.shutdownButton.UseVisualStyleBackColor = false;
@@ -132,10 +131,10 @@
             this.txtPLCPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.txtPLCPort.BackColor = System.Drawing.Color.Gainsboro;
             this.txtPLCPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.txtPLCPort.Location = new System.Drawing.Point(249, 49);
-            this.txtPLCPort.Margin = new System.Windows.Forms.Padding(2);
+            this.txtPLCPort.Location = new System.Drawing.Point(332, 60);
+            this.txtPLCPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtPLCPort.Name = "txtPLCPort";
-            this.txtPLCPort.Size = new System.Drawing.Size(118, 29);
+            this.txtPLCPort.Size = new System.Drawing.Size(156, 34);
             this.txtPLCPort.TabIndex = 5;
             this.txtPLCPort.TextChanged += new System.EventHandler(this.txtPLCPort_TextChanged);
             // 
@@ -149,10 +148,10 @@
             this.comboBox1.Items.AddRange(new object[] {
             "Production SpectraCyber",
             "Simulated SpectraCyber"});
-            this.comboBox1.Location = new System.Drawing.Point(6, 47);
-            this.comboBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBox1.Location = new System.Drawing.Point(8, 58);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(246, 28);
+            this.comboBox1.Size = new System.Drawing.Size(327, 33);
             this.comboBox1.TabIndex = 2;
             this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
             // 
@@ -161,10 +160,10 @@
             this.txtPLCIP.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.txtPLCIP.BackColor = System.Drawing.Color.Gainsboro;
             this.txtPLCIP.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.txtPLCIP.Location = new System.Drawing.Point(249, 13);
-            this.txtPLCIP.Margin = new System.Windows.Forms.Padding(2);
+            this.txtPLCIP.Location = new System.Drawing.Point(332, 16);
+            this.txtPLCIP.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtPLCIP.Name = "txtPLCIP";
-            this.txtPLCIP.Size = new System.Drawing.Size(118, 29);
+            this.txtPLCIP.Size = new System.Drawing.Size(156, 34);
             this.txtPLCIP.TabIndex = 4;
             this.txtPLCIP.TextChanged += new System.EventHandler(this.txtPLCIP_TextChanged);
             // 
@@ -179,10 +178,10 @@
             "Production Weather Station",
             "Simulated Weather Station",
             "Test Weather Station"});
-            this.comboBox2.Location = new System.Drawing.Point(5, 77);
-            this.comboBox2.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBox2.Location = new System.Drawing.Point(7, 95);
+            this.comboBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBox2.Name = "comboBox2";
-            this.comboBox2.Size = new System.Drawing.Size(247, 28);
+            this.comboBox2.Size = new System.Drawing.Size(328, 33);
             this.comboBox2.TabIndex = 1;
             this.comboBox2.SelectedIndexChanged += new System.EventHandler(this.comboBox2_SelectedIndexChanged);
             // 
@@ -198,10 +197,10 @@
             "Scale PLC",
             "Simulated PLC",
             "Test PLC"});
-            this.comboPLCType.Location = new System.Drawing.Point(5, 107);
-            this.comboPLCType.Margin = new System.Windows.Forms.Padding(2);
+            this.comboPLCType.Location = new System.Drawing.Point(7, 132);
+            this.comboPLCType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboPLCType.Name = "comboPLCType";
-            this.comboPLCType.Size = new System.Drawing.Size(247, 28);
+            this.comboPLCType.Size = new System.Drawing.Size(328, 33);
             this.comboPLCType.TabIndex = 3;
             this.comboPLCType.SelectedIndexChanged += new System.EventHandler(this.comboPLCType_SelectedIndexChanged);
             // 
@@ -212,10 +211,10 @@
             this.FreeControl.Enabled = false;
             this.FreeControl.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.FreeControl.Font = new System.Drawing.Font("Microsoft Sans Serif", 18F);
-            this.FreeControl.Location = new System.Drawing.Point(13, 15);
-            this.FreeControl.Margin = new System.Windows.Forms.Padding(2);
+            this.FreeControl.Location = new System.Drawing.Point(17, 18);
+            this.FreeControl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.FreeControl.Name = "FreeControl";
-            this.FreeControl.Size = new System.Drawing.Size(354, 44);
+            this.FreeControl.Size = new System.Drawing.Size(472, 54);
             this.FreeControl.TabIndex = 9;
             this.FreeControl.Text = "Radio Telescope Control";
             this.FreeControl.UseVisualStyleBackColor = false;
@@ -230,18 +229,19 @@
             this.comboSensorNetworkBox.Items.AddRange(new object[] {
             "Production Sensor Network",
             "Simulated Sensor Network"});
-            this.comboSensorNetworkBox.Location = new System.Drawing.Point(6, 17);
+            this.comboSensorNetworkBox.Location = new System.Drawing.Point(8, 21);
+            this.comboSensorNetworkBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.comboSensorNetworkBox.Name = "comboSensorNetworkBox";
-            this.comboSensorNetworkBox.Size = new System.Drawing.Size(246, 28);
+            this.comboSensorNetworkBox.Size = new System.Drawing.Size(327, 33);
             this.comboSensorNetworkBox.TabIndex = 14;
             this.comboSensorNetworkBox.SelectedIndexChanged += new System.EventHandler(this.comboSensorNetworkBox_SelectedIndexChanged);
             // 
             // loopBackBox
             // 
-            this.loopBackBox.Location = new System.Drawing.Point(539, 219);
-            this.loopBackBox.Margin = new System.Windows.Forms.Padding(2);
+            this.loopBackBox.Location = new System.Drawing.Point(719, 270);
+            this.loopBackBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.loopBackBox.Name = "loopBackBox";
-            this.loopBackBox.Size = new System.Drawing.Size(160, 43);
+            this.loopBackBox.Size = new System.Drawing.Size(213, 53);
             this.loopBackBox.TabIndex = 28;
             this.loopBackBox.Text = "Loop back (for simulation)";
             this.loopBackBox.UseVisualStyleBackColor = true;
@@ -257,20 +257,19 @@
             this.LocalIPCombo.Items.AddRange(new object[] {
             "RT IP Address",
             "127.0.0.1"});
-            this.LocalIPCombo.Location = new System.Drawing.Point(6, 137);
-            this.LocalIPCombo.Margin = new System.Windows.Forms.Padding(2);
+            this.LocalIPCombo.Location = new System.Drawing.Point(8, 169);
+            this.LocalIPCombo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.LocalIPCombo.Name = "LocalIPCombo";
-            this.LocalIPCombo.Size = new System.Drawing.Size(246, 28);
+            this.LocalIPCombo.Size = new System.Drawing.Size(327, 33);
             this.LocalIPCombo.TabIndex = 16;
             this.LocalIPCombo.SelectedIndexChanged += new System.EventHandler(this.LocalIPCombo_SelectedIndexChanged);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 7);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label1.Location = new System.Drawing.Point(12, 9);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(271, 13);
+            this.label1.Size = new System.Drawing.Size(359, 17);
             this.label1.TabIndex = 17;
             this.label1.Text = "Click on the IP adress of the RT to open diagnostic form";
             // 
@@ -287,9 +286,11 @@
             this.simulationSettingsGroupbox.Controls.Add(this.label2);
             this.simulationSettingsGroupbox.Controls.Add(this.txtWSCOMPort);
             this.simulationSettingsGroupbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.simulationSettingsGroupbox.Location = new System.Drawing.Point(12, 258);
+            this.simulationSettingsGroupbox.Location = new System.Drawing.Point(16, 318);
+            this.simulationSettingsGroupbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.simulationSettingsGroupbox.Name = "simulationSettingsGroupbox";
-            this.simulationSettingsGroupbox.Size = new System.Drawing.Size(499, 170);
+            this.simulationSettingsGroupbox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.simulationSettingsGroupbox.Size = new System.Drawing.Size(665, 209);
             this.simulationSettingsGroupbox.TabIndex = 18;
             this.simulationSettingsGroupbox.TabStop = false;
             this.simulationSettingsGroupbox.Text = "Individual Component Simulation settings";
@@ -299,9 +300,10 @@
             // 
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(257, 57);
+            this.label8.Location = new System.Drawing.Point(343, 70);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(120, 18);
+            this.label8.Size = new System.Drawing.Size(148, 24);
             this.label8.TabIndex = 23;
             this.label8.Text = "Spectra Cyber:";
             this.WCOMPortToolTip.SetToolTip(this.label8, "Enter a valid port number, between 1 and 65536");
@@ -312,10 +314,10 @@
             this.txtSpectraPort.BackColor = System.Drawing.Color.Gainsboro;
             this.txtSpectraPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
             this.txtSpectraPort.ForeColor = System.Drawing.Color.DarkGray;
-            this.txtSpectraPort.Location = new System.Drawing.Point(389, 53);
-            this.txtSpectraPort.Margin = new System.Windows.Forms.Padding(2);
+            this.txtSpectraPort.Location = new System.Drawing.Point(519, 65);
+            this.txtSpectraPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtSpectraPort.Name = "txtSpectraPort";
-            this.txtSpectraPort.Size = new System.Drawing.Size(104, 29);
+            this.txtSpectraPort.Size = new System.Drawing.Size(137, 34);
             this.txtSpectraPort.TabIndex = 24;
             this.txtSpectraPort.Text = " COM port";
             this.txtSpectraPort.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
@@ -326,9 +328,10 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(258, 21);
+            this.label2.Location = new System.Drawing.Point(344, 26);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(132, 18);
+            this.label2.Size = new System.Drawing.Size(160, 24);
             this.label2.TabIndex = 17;
             this.label2.Text = "Weather station:";
             this.WCOMPortToolTip.SetToolTip(this.label2, "Enter a valid port number, between 1 and 65536");
@@ -340,10 +343,10 @@
             this.txtWSCOMPort.BackColor = System.Drawing.Color.Gainsboro;
             this.txtWSCOMPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
             this.txtWSCOMPort.ForeColor = System.Drawing.Color.DarkGray;
-            this.txtWSCOMPort.Location = new System.Drawing.Point(390, 17);
-            this.txtWSCOMPort.Margin = new System.Windows.Forms.Padding(2);
+            this.txtWSCOMPort.Location = new System.Drawing.Point(520, 21);
+            this.txtWSCOMPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtWSCOMPort.Name = "txtWSCOMPort";
-            this.txtWSCOMPort.Size = new System.Drawing.Size(104, 29);
+            this.txtWSCOMPort.Size = new System.Drawing.Size(137, 34);
             this.txtWSCOMPort.TabIndex = 22;
             this.txtWSCOMPort.Text = " COM port";
             this.txtWSCOMPort.TextChanged += new System.EventHandler(this.txtWSCOMPort_TextChanged);
@@ -354,9 +357,10 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(4, 56);
+            this.label3.Location = new System.Drawing.Point(5, 69);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(85, 18);
+            this.label3.Size = new System.Drawing.Size(102, 24);
             this.label3.TabIndex = 19;
             this.label3.Text = " PLC port:";
             this.PLCPortToolTip.SetToolTip(this.label3, "Enter a valid port number, between 1 and 65536");
@@ -366,9 +370,10 @@
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(8, 23);
+            this.label4.Location = new System.Drawing.Point(11, 28);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(137, 18);
+            this.label4.Size = new System.Drawing.Size(168, 24);
             this.label4.TabIndex = 20;
             this.label4.Text = "MCU IP Address:";
             this.MCUIPToolTip.SetToolTip(this.label4, "Enter a valid IP Address (in the form xxx.xxx.xxx.xxx)");
@@ -388,9 +393,11 @@
             this.portGroupbox.Controls.Add(this.label4);
             this.portGroupbox.Controls.Add(this.txtPLCIP);
             this.portGroupbox.Controls.Add(this.label3);
-            this.portGroupbox.Location = new System.Drawing.Point(526, 25);
+            this.portGroupbox.Location = new System.Drawing.Point(701, 31);
+            this.portGroupbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.portGroupbox.Name = "portGroupbox";
-            this.portGroupbox.Size = new System.Drawing.Size(373, 195);
+            this.portGroupbox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.portGroupbox.Size = new System.Drawing.Size(497, 240);
             this.portGroupbox.TabIndex = 21;
             this.portGroupbox.TabStop = false;
             this.portGroupbox.Text = "System IP Address and Port Numbers";
@@ -400,9 +407,10 @@
             // 
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(9, 162);
+            this.label7.Location = new System.Drawing.Point(12, 199);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(183, 18);
+            this.label7.Size = new System.Drawing.Size(223, 24);
             this.label7.TabIndex = 28;
             this.label7.Text = "Sensor Network Client:";
             this.WCOMPortToolTip.SetToolTip(this.label7, "Enter a valid port number, between 1 and 65536");
@@ -411,9 +419,10 @@
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(9, 127);
+            this.label6.Location = new System.Drawing.Point(12, 156);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(183, 18);
+            this.label6.Size = new System.Drawing.Size(224, 24);
             this.label6.TabIndex = 27;
             this.label6.Text = "Sensor Network Sever:";
             this.WCOMPortToolTip.SetToolTip(this.label6, "Enter a valid port number, between 1 and 65536");
@@ -423,10 +432,10 @@
             this.sensorNetworkClientPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.sensorNetworkClientPort.BackColor = System.Drawing.Color.Gainsboro;
             this.sensorNetworkClientPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.sensorNetworkClientPort.Location = new System.Drawing.Point(303, 157);
-            this.sensorNetworkClientPort.Margin = new System.Windows.Forms.Padding(2);
+            this.sensorNetworkClientPort.Location = new System.Drawing.Point(404, 193);
+            this.sensorNetworkClientPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.sensorNetworkClientPort.Name = "sensorNetworkClientPort";
-            this.sensorNetworkClientPort.Size = new System.Drawing.Size(64, 29);
+            this.sensorNetworkClientPort.Size = new System.Drawing.Size(84, 34);
             this.sensorNetworkClientPort.TabIndex = 26;
             this.sensorNetworkClientPort.TextChanged += new System.EventHandler(this.sensorNetworkClientPort_TextChanged);
             this.sensorNetworkClientPort.Enter += new System.EventHandler(this.sensorNetworkClientPort_Enter);
@@ -437,10 +446,10 @@
             this.sensorNetworkClientIPAddress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.sensorNetworkClientIPAddress.BackColor = System.Drawing.Color.Gainsboro;
             this.sensorNetworkClientIPAddress.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.sensorNetworkClientIPAddress.Location = new System.Drawing.Point(197, 157);
-            this.sensorNetworkClientIPAddress.Margin = new System.Windows.Forms.Padding(2);
+            this.sensorNetworkClientIPAddress.Location = new System.Drawing.Point(263, 193);
+            this.sensorNetworkClientIPAddress.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.sensorNetworkClientIPAddress.Name = "sensorNetworkClientIPAddress";
-            this.sensorNetworkClientIPAddress.Size = new System.Drawing.Size(104, 29);
+            this.sensorNetworkClientIPAddress.Size = new System.Drawing.Size(137, 34);
             this.sensorNetworkClientIPAddress.TabIndex = 25;
             this.sensorNetworkClientIPAddress.TextChanged += new System.EventHandler(this.sensorNetworkClientIPAddress_TextChanged);
             this.sensorNetworkClientIPAddress.Enter += new System.EventHandler(this.sensorNetworkClientIPAddress_Enter);
@@ -451,10 +460,10 @@
             this.sensorNetworkServerPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.sensorNetworkServerPort.BackColor = System.Drawing.Color.Gainsboro;
             this.sensorNetworkServerPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.sensorNetworkServerPort.Location = new System.Drawing.Point(303, 121);
-            this.sensorNetworkServerPort.Margin = new System.Windows.Forms.Padding(2);
+            this.sensorNetworkServerPort.Location = new System.Drawing.Point(404, 149);
+            this.sensorNetworkServerPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.sensorNetworkServerPort.Name = "sensorNetworkServerPort";
-            this.sensorNetworkServerPort.Size = new System.Drawing.Size(64, 29);
+            this.sensorNetworkServerPort.Size = new System.Drawing.Size(84, 34);
             this.sensorNetworkServerPort.TabIndex = 24;
             this.sensorNetworkServerPort.TextChanged += new System.EventHandler(this.sensorNetworkServerPort_TextChanged);
             this.sensorNetworkServerPort.Enter += new System.EventHandler(this.sensorNetworkServerPort_Enter);
@@ -465,10 +474,10 @@
             this.sensorNetworkServerIPAddress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.sensorNetworkServerIPAddress.BackColor = System.Drawing.Color.Gainsboro;
             this.sensorNetworkServerIPAddress.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.sensorNetworkServerIPAddress.Location = new System.Drawing.Point(197, 121);
-            this.sensorNetworkServerIPAddress.Margin = new System.Windows.Forms.Padding(2);
+            this.sensorNetworkServerIPAddress.Location = new System.Drawing.Point(263, 149);
+            this.sensorNetworkServerIPAddress.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.sensorNetworkServerIPAddress.Name = "sensorNetworkServerIPAddress";
-            this.sensorNetworkServerIPAddress.Size = new System.Drawing.Size(104, 29);
+            this.sensorNetworkServerIPAddress.Size = new System.Drawing.Size(137, 34);
             this.sensorNetworkServerIPAddress.TabIndex = 23;
             this.sensorNetworkServerIPAddress.TextChanged += new System.EventHandler(this.sensorNetworkServerIPAddress_TextChanged);
             this.sensorNetworkServerIPAddress.Enter += new System.EventHandler(this.sensorNetworkServerIPAddress_Enter);
@@ -479,10 +488,10 @@
             this.txtMcuCOMPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.txtMcuCOMPort.BackColor = System.Drawing.Color.Gainsboro;
             this.txtMcuCOMPort.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
-            this.txtMcuCOMPort.Location = new System.Drawing.Point(249, 85);
-            this.txtMcuCOMPort.Margin = new System.Windows.Forms.Padding(2);
+            this.txtMcuCOMPort.Location = new System.Drawing.Point(332, 105);
+            this.txtMcuCOMPort.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtMcuCOMPort.Name = "txtMcuCOMPort";
-            this.txtMcuCOMPort.Size = new System.Drawing.Size(118, 29);
+            this.txtMcuCOMPort.Size = new System.Drawing.Size(156, 34);
             this.txtMcuCOMPort.TabIndex = 18;
             this.txtMcuCOMPort.TextChanged += new System.EventHandler(this.txtMcuCOMPort_TextChanged);
             // 
@@ -490,29 +499,14 @@
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(9, 93);
+            this.label5.Location = new System.Drawing.Point(12, 114);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(93, 18);
+            this.label5.Size = new System.Drawing.Size(110, 24);
             this.label5.TabIndex = 21;
             this.label5.Text = "MCU Port: ";
             this.MCUPortToolTip.SetToolTip(this.label5, "Enter a valid port number, between 1 and 65536");
             this.label5.Click += new System.EventHandler(this.label5_MouseHover);
-            // 
-            // createWSButton
-            // 
-            this.createWSButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.createWSButton.BackColor = System.Drawing.Color.LightGray;
-            this.createWSButton.Enabled = false;
-            this.createWSButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.createWSButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.createWSButton.Location = new System.Drawing.Point(723, 262);
-            this.createWSButton.Margin = new System.Windows.Forms.Padding(2);
-            this.createWSButton.Name = "createWSButton";
-            this.createWSButton.Size = new System.Drawing.Size(170, 51);
-            this.createWSButton.TabIndex = 22;
-            this.createWSButton.Text = "Create Production Weather Station";
-            this.createWSButton.UseVisualStyleBackColor = false;
-            this.createWSButton.Click += new System.EventHandler(this.createWSButton_Click);
             // 
             // acceptSettings
             // 
@@ -521,10 +515,10 @@
             this.acceptSettings.Enabled = false;
             this.acceptSettings.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.acceptSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.acceptSettings.Location = new System.Drawing.Point(539, 262);
-            this.acceptSettings.Margin = new System.Windows.Forms.Padding(2);
+            this.acceptSettings.Location = new System.Drawing.Point(719, 322);
+            this.acceptSettings.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.acceptSettings.Name = "acceptSettings";
-            this.acceptSettings.Size = new System.Drawing.Size(170, 51);
+            this.acceptSettings.Size = new System.Drawing.Size(470, 63);
             this.acceptSettings.TabIndex = 23;
             this.acceptSettings.Text = "Finalize settings";
             this.acceptSettings.UseVisualStyleBackColor = false;
@@ -535,9 +529,11 @@
             this.startRTGroupbox.Controls.Add(this.FreeControl);
             this.startRTGroupbox.Controls.Add(this.shutdownButton);
             this.startRTGroupbox.Controls.Add(this.startButton);
-            this.startRTGroupbox.Location = new System.Drawing.Point(526, 315);
+            this.startRTGroupbox.Location = new System.Drawing.Point(701, 388);
+            this.startRTGroupbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.startRTGroupbox.Name = "startRTGroupbox";
-            this.startRTGroupbox.Size = new System.Drawing.Size(381, 113);
+            this.startRTGroupbox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.startRTGroupbox.Size = new System.Drawing.Size(508, 139);
             this.startRTGroupbox.TabIndex = 24;
             this.startRTGroupbox.TabStop = false;
             this.startRTGroupbox.Enter += new System.EventHandler(this.groupBox3_Enter);
@@ -548,9 +544,10 @@
             this.helpButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.helpButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.helpButton.ForeColor = System.Drawing.SystemColors.Desktop;
-            this.helpButton.Location = new System.Drawing.Point(879, 2);
+            this.helpButton.Location = new System.Drawing.Point(1172, 2);
+            this.helpButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.helpButton.Name = "helpButton";
-            this.helpButton.Size = new System.Drawing.Size(22, 24);
+            this.helpButton.Size = new System.Drawing.Size(29, 30);
             this.helpButton.TabIndex = 27;
             this.helpButton.Text = "?";
             this.helpButton.UseVisualStyleBackColor = false;
@@ -558,10 +555,10 @@
             // 
             // ProdcheckBox
             // 
-            this.ProdcheckBox.Location = new System.Drawing.Point(726, 225);
-            this.ProdcheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.ProdcheckBox.Location = new System.Drawing.Point(968, 277);
+            this.ProdcheckBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ProdcheckBox.Name = "ProdcheckBox";
-            this.ProdcheckBox.Size = new System.Drawing.Size(175, 30);
+            this.ProdcheckBox.Size = new System.Drawing.Size(233, 37);
             this.ProdcheckBox.TabIndex = 28;
             this.ProdcheckBox.Text = "Default Vals (for production)";
             this.ProdcheckBox.UseVisualStyleBackColor = true;
@@ -573,14 +570,13 @@
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Gray;
-            this.ClientSize = new System.Drawing.Size(911, 432);
+            this.ClientSize = new System.Drawing.Size(1215, 532);
             this.Controls.Add(this.helpButton);
             this.Controls.Add(this.startRTGroupbox);
             this.Controls.Add(this.acceptSettings);
-            this.Controls.Add(this.createWSButton);
             this.Controls.Add(this.portGroupbox);
             this.Controls.Add(this.simulationSettingsGroupbox);
             this.Controls.Add(this.label1);
@@ -588,8 +584,8 @@
             this.Controls.Add(this.loopBackBox);
             this.Controls.Add(this.ProdcheckBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(2);
-            this.MinimumSize = new System.Drawing.Size(920, 365);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.MinimumSize = new System.Drawing.Size(1221, 438);
             this.Name = "MainForm";
             this.Text = "MainForm";
             this.Load += new System.EventHandler(this.MainForm_Load);
@@ -627,7 +623,6 @@
         private System.Windows.Forms.GroupBox portGroupbox;
         private System.Windows.Forms.TextBox txtMcuCOMPort;
         private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Button createWSButton;
         private System.Windows.Forms.Button acceptSettings;
         private System.Windows.Forms.GroupBox startRTGroupbox;
         private System.Windows.Forms.Button helpButton;

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -111,7 +111,6 @@ namespace ControlRoomApplication.Main
 
             // Initialize Button Settings 
             startRTGroupbox.BackColor = System.Drawing.Color.DarkGray;
-            createWSButton.Enabled = true;
             acceptSettings.Enabled = false;
             startButton.BackColor = System.Drawing.Color.Gainsboro;
             startButton.Enabled = false;
@@ -606,8 +605,14 @@ namespace ControlRoomApplication.Main
             {
                 case 0:
                     logger.Info(Utilities.GetTimeStamp() + ": Building ProductionWeatherStation");
+                    try
+                    {
                     return new WeatherStation(1000, int.Parse(txtWSCOMPort.Text));
-
+                    }catch(Exception e)
+                    {
+                        return null;
+                    }
+                    
                 case 2:
                     logger.Error(Utilities.GetTimeStamp() + ": The test weather station is not yet supported.");
                     throw new NotImplementedException("The test weather station is not yet supported.");
@@ -725,12 +730,6 @@ namespace ControlRoomApplication.Main
             this.comboPLCType.SelectedIndex = this.comboPLCType.FindStringExact("Production PLC");
         }
 
-        private void createWSButton_Click(object sender, EventArgs e)
-        {
-            startButton.BackColor = System.Drawing.Color.LimeGreen;
-            startButton.Enabled = true;
-            lastCreatedProductionWeatherStation = BuildWeatherStation();
-        }
 
         private void comboSensorNetworkBox_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -872,16 +871,48 @@ namespace ControlRoomApplication.Main
         private void acceptSettings_Click(object sender, EventArgs e)
         {
             finalSettings = !finalSettings;
+
             if (finalSettings == false)
             {
 
-                //Editing text to relflect state -- When the settings are being edited, the button will need to say 'finalize'
-                acceptSettings.Text = "Edit Settings";
-                if (comboBox2.Text != "Production Weather Station")
+                if (comboBox2.Text == "Production Weather Station")
                 {
+                    
+                    lastCreatedProductionWeatherStation = BuildWeatherStation();
+                   
+                    if (lastCreatedProductionWeatherStation != null)
+                    {
+                        
+                        startButton.BackColor = System.Drawing.Color.LimeGreen;
+                        startButton.Enabled = true;
+                    }
+                    else
+                    {
+                        this.WCOMPortToolTip.Show("Could not create production weather station on this port.", label8);
+                        txtWSCOMPort.BackColor = System.Drawing.Color.Yellow;
+
+
+                    }
+
+                }
+                else
+                {
+
                     startButton.BackColor = System.Drawing.Color.LimeGreen;
                     startButton.Enabled = true;
                 }
+
+                //if there is an error with the production weather station, display a tooltip & do not let the user start the telescope
+
+
+
+                //Editing text to relflect state -- When the settings are being edited, the button will need to say 'finalize'
+                acceptSettings.Text = "Edit Settings";
+
+
+
+
+
                 startRTGroupbox.BackColor = System.Drawing.Color.Gray;
                 loopBackBox.Enabled = false;
 
@@ -910,6 +941,11 @@ namespace ControlRoomApplication.Main
             {
                 // Editing Text to reflect state -- when finalized, you can click "edit settings"
                 acceptSettings.Text = "Finalize Settings";
+                
+                //hide WS error
+                this.WCOMPortToolTip.Hide(label8);
+                txtWSCOMPort.BackColor = System.Drawing.Color.White;
+
 
                 startRTGroupbox.BackColor = System.Drawing.Color.DarkGray;
                 startButton.Enabled = false;

--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
@@ -1081,5 +1081,10 @@ namespace ControlRoomApplication.Main
         {
 
         }
+
+        private void FreeControlForm_Load(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
@@ -114,9 +114,10 @@ namespace ControlRoomApplication.Main
             this.PosDecButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.PosDecButton.BackColor = System.Drawing.Color.DarkGray;
             this.PosDecButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.PosDecButton.Location = new System.Drawing.Point(297, 56);
+            this.PosDecButton.Location = new System.Drawing.Point(396, 69);
+            this.PosDecButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.PosDecButton.Name = "PosDecButton";
-            this.PosDecButton.Size = new System.Drawing.Size(40, 40);
+            this.PosDecButton.Size = new System.Drawing.Size(53, 49);
             this.PosDecButton.TabIndex = 0;
             this.PosDecButton.Text = "+ Dec";
             this.PosDecButton.UseVisualStyleBackColor = false;
@@ -127,9 +128,10 @@ namespace ControlRoomApplication.Main
             this.NegDecButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.NegDecButton.BackColor = System.Drawing.Color.DarkGray;
             this.NegDecButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.NegDecButton.Location = new System.Drawing.Point(296, 151);
+            this.NegDecButton.Location = new System.Drawing.Point(395, 186);
+            this.NegDecButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NegDecButton.Name = "NegDecButton";
-            this.NegDecButton.Size = new System.Drawing.Size(40, 40);
+            this.NegDecButton.Size = new System.Drawing.Size(53, 49);
             this.NegDecButton.TabIndex = 1;
             this.NegDecButton.Text = "- Dec";
             this.NegDecButton.UseVisualStyleBackColor = false;
@@ -140,9 +142,10 @@ namespace ControlRoomApplication.Main
             this.NegRAButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.NegRAButton.BackColor = System.Drawing.Color.DarkGray;
             this.NegRAButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.NegRAButton.Location = new System.Drawing.Point(250, 105);
+            this.NegRAButton.Location = new System.Drawing.Point(333, 129);
+            this.NegRAButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NegRAButton.Name = "NegRAButton";
-            this.NegRAButton.Size = new System.Drawing.Size(40, 40);
+            this.NegRAButton.Size = new System.Drawing.Size(53, 49);
             this.NegRAButton.TabIndex = 2;
             this.NegRAButton.Text = "- RA";
             this.NegRAButton.UseVisualStyleBackColor = false;
@@ -153,9 +156,10 @@ namespace ControlRoomApplication.Main
             this.PosRAButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.PosRAButton.BackColor = System.Drawing.Color.DarkGray;
             this.PosRAButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.PosRAButton.Location = new System.Drawing.Point(341, 105);
+            this.PosRAButton.Location = new System.Drawing.Point(455, 129);
+            this.PosRAButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.PosRAButton.Name = "PosRAButton";
-            this.PosRAButton.Size = new System.Drawing.Size(40, 40);
+            this.PosRAButton.Size = new System.Drawing.Size(53, 49);
             this.PosRAButton.TabIndex = 3;
             this.PosRAButton.Text = "+ RA";
             this.PosRAButton.UseVisualStyleBackColor = false;
@@ -164,10 +168,11 @@ namespace ControlRoomApplication.Main
             // ActualRATextBox
             // 
             this.ActualRATextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.ActualRATextBox.Location = new System.Drawing.Point(153, 74);
+            this.ActualRATextBox.Location = new System.Drawing.Point(204, 91);
+            this.ActualRATextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ActualRATextBox.Name = "ActualRATextBox";
             this.ActualRATextBox.ReadOnly = true;
-            this.ActualRATextBox.Size = new System.Drawing.Size(100, 20);
+            this.ActualRATextBox.Size = new System.Drawing.Size(132, 22);
             this.ActualRATextBox.TabIndex = 5;
             // 
             // ActualPositionLabel
@@ -175,9 +180,10 @@ namespace ControlRoomApplication.Main
             this.ActualPositionLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.ActualPositionLabel.AutoSize = true;
             this.ActualPositionLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            this.ActualPositionLabel.Location = new System.Drawing.Point(149, 27);
+            this.ActualPositionLabel.Location = new System.Drawing.Point(199, 33);
+            this.ActualPositionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ActualPositionLabel.Name = "ActualPositionLabel";
-            this.ActualPositionLabel.Size = new System.Drawing.Size(114, 20);
+            this.ActualPositionLabel.Size = new System.Drawing.Size(141, 25);
             this.ActualPositionLabel.TabIndex = 7;
             this.ActualPositionLabel.Text = "Actual Position";
             // 
@@ -185,9 +191,10 @@ namespace ControlRoomApplication.Main
             // 
             this.ActualRALabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.ActualRALabel.AutoSize = true;
-            this.ActualRALabel.Location = new System.Drawing.Point(150, 56);
+            this.ActualRALabel.Location = new System.Drawing.Point(200, 69);
+            this.ActualRALabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ActualRALabel.Name = "ActualRALabel";
-            this.ActualRALabel.Size = new System.Drawing.Size(84, 13);
+            this.ActualRALabel.Size = new System.Drawing.Size(110, 17);
             this.ActualRALabel.TabIndex = 8;
             this.ActualRALabel.Text = "Right Ascension";
             // 
@@ -195,9 +202,10 @@ namespace ControlRoomApplication.Main
             // 
             this.ActualDecLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.ActualDecLabel.AutoSize = true;
-            this.ActualDecLabel.Location = new System.Drawing.Point(151, 102);
+            this.ActualDecLabel.Location = new System.Drawing.Point(201, 126);
+            this.ActualDecLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ActualDecLabel.Name = "ActualDecLabel";
-            this.ActualDecLabel.Size = new System.Drawing.Size(60, 13);
+            this.ActualDecLabel.Size = new System.Drawing.Size(78, 17);
             this.ActualDecLabel.TabIndex = 9;
             this.ActualDecLabel.Text = "Declination";
             // 
@@ -205,9 +213,10 @@ namespace ControlRoomApplication.Main
             // 
             this.TargetDecLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.TargetDecLabel.AutoSize = true;
-            this.TargetDecLabel.Location = new System.Drawing.Point(18, 102);
+            this.TargetDecLabel.Location = new System.Drawing.Point(24, 126);
+            this.TargetDecLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.TargetDecLabel.Name = "TargetDecLabel";
-            this.TargetDecLabel.Size = new System.Drawing.Size(60, 13);
+            this.TargetDecLabel.Size = new System.Drawing.Size(78, 17);
             this.TargetDecLabel.TabIndex = 14;
             this.TargetDecLabel.Text = "Declination";
             // 
@@ -215,9 +224,10 @@ namespace ControlRoomApplication.Main
             // 
             this.TargetRALabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.TargetRALabel.AutoSize = true;
-            this.TargetRALabel.Location = new System.Drawing.Point(16, 56);
+            this.TargetRALabel.Location = new System.Drawing.Point(21, 69);
+            this.TargetRALabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.TargetRALabel.Name = "TargetRALabel";
-            this.TargetRALabel.Size = new System.Drawing.Size(84, 13);
+            this.TargetRALabel.Size = new System.Drawing.Size(110, 17);
             this.TargetRALabel.TabIndex = 13;
             this.TargetRALabel.Text = "Right Ascension";
             // 
@@ -226,28 +236,31 @@ namespace ControlRoomApplication.Main
             this.TargetPositionLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.TargetPositionLabel.AutoSize = true;
             this.TargetPositionLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            this.TargetPositionLabel.Location = new System.Drawing.Point(12, 27);
+            this.TargetPositionLabel.Location = new System.Drawing.Point(16, 33);
+            this.TargetPositionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.TargetPositionLabel.Name = "TargetPositionLabel";
-            this.TargetPositionLabel.Size = new System.Drawing.Size(115, 20);
+            this.TargetPositionLabel.Size = new System.Drawing.Size(143, 25);
             this.TargetPositionLabel.TabIndex = 12;
             this.TargetPositionLabel.Text = "Target Position";
             // 
             // TargetDecTextBox
             // 
             this.TargetDecTextBox.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.TargetDecTextBox.Location = new System.Drawing.Point(20, 120);
+            this.TargetDecTextBox.Location = new System.Drawing.Point(27, 148);
+            this.TargetDecTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.TargetDecTextBox.Name = "TargetDecTextBox";
             this.TargetDecTextBox.ReadOnly = true;
-            this.TargetDecTextBox.Size = new System.Drawing.Size(100, 20);
+            this.TargetDecTextBox.Size = new System.Drawing.Size(132, 22);
             this.TargetDecTextBox.TabIndex = 11;
             // 
             // TargetRATextBox
             // 
             this.TargetRATextBox.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.TargetRATextBox.Location = new System.Drawing.Point(19, 74);
+            this.TargetRATextBox.Location = new System.Drawing.Point(25, 91);
+            this.TargetRATextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.TargetRATextBox.Name = "TargetRATextBox";
             this.TargetRATextBox.ReadOnly = true;
-            this.TargetRATextBox.Size = new System.Drawing.Size(100, 20);
+            this.TargetRATextBox.Size = new System.Drawing.Size(132, 22);
             this.TargetRATextBox.TabIndex = 10;
             // 
             // timer1
@@ -264,11 +277,11 @@ namespace ControlRoomApplication.Main
             this.RAIncGroupbox.Controls.Add(this.fiveButton);
             this.RAIncGroupbox.Controls.Add(this.oneButton);
             this.RAIncGroupbox.Controls.Add(this.oneForthButton);
-            this.RAIncGroupbox.Location = new System.Drawing.Point(4, 45);
-            this.RAIncGroupbox.Margin = new System.Windows.Forms.Padding(2);
+            this.RAIncGroupbox.Location = new System.Drawing.Point(5, 55);
+            this.RAIncGroupbox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.RAIncGroupbox.Name = "RAIncGroupbox";
-            this.RAIncGroupbox.Padding = new System.Windows.Forms.Padding(2);
-            this.RAIncGroupbox.Size = new System.Drawing.Size(188, 54);
+            this.RAIncGroupbox.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.RAIncGroupbox.Size = new System.Drawing.Size(251, 66);
             this.RAIncGroupbox.TabIndex = 16;
             this.RAIncGroupbox.TabStop = false;
             this.RAIncGroupbox.Text = "Right Ascension Increment";
@@ -277,10 +290,10 @@ namespace ControlRoomApplication.Main
             // 
             this.tenButton.BackColor = System.Drawing.Color.DarkGray;
             this.tenButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.tenButton.Location = new System.Drawing.Point(136, 15);
-            this.tenButton.Margin = new System.Windows.Forms.Padding(2);
+            this.tenButton.Location = new System.Drawing.Point(181, 18);
+            this.tenButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tenButton.Name = "tenButton";
-            this.tenButton.Size = new System.Drawing.Size(40, 30);
+            this.tenButton.Size = new System.Drawing.Size(53, 37);
             this.tenButton.TabIndex = 3;
             this.tenButton.Text = "10";
             this.tenButton.UseVisualStyleBackColor = false;
@@ -290,10 +303,10 @@ namespace ControlRoomApplication.Main
             // 
             this.fiveButton.BackColor = System.Drawing.Color.DarkGray;
             this.fiveButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.fiveButton.Location = new System.Drawing.Point(93, 15);
-            this.fiveButton.Margin = new System.Windows.Forms.Padding(2);
+            this.fiveButton.Location = new System.Drawing.Point(124, 18);
+            this.fiveButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.fiveButton.Name = "fiveButton";
-            this.fiveButton.Size = new System.Drawing.Size(40, 30);
+            this.fiveButton.Size = new System.Drawing.Size(53, 37);
             this.fiveButton.TabIndex = 2;
             this.fiveButton.Text = "5";
             this.fiveButton.UseVisualStyleBackColor = false;
@@ -303,10 +316,10 @@ namespace ControlRoomApplication.Main
             // 
             this.oneButton.BackColor = System.Drawing.Color.DarkGray;
             this.oneButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.oneButton.Location = new System.Drawing.Point(49, 15);
-            this.oneButton.Margin = new System.Windows.Forms.Padding(2);
+            this.oneButton.Location = new System.Drawing.Point(65, 18);
+            this.oneButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.oneButton.Name = "oneButton";
-            this.oneButton.Size = new System.Drawing.Size(40, 30);
+            this.oneButton.Size = new System.Drawing.Size(53, 37);
             this.oneButton.TabIndex = 1;
             this.oneButton.Text = "1";
             this.oneButton.UseVisualStyleBackColor = false;
@@ -316,10 +329,10 @@ namespace ControlRoomApplication.Main
             // 
             this.oneForthButton.BackColor = System.Drawing.Color.DarkGray;
             this.oneForthButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.oneForthButton.Location = new System.Drawing.Point(5, 15);
-            this.oneForthButton.Margin = new System.Windows.Forms.Padding(2);
+            this.oneForthButton.Location = new System.Drawing.Point(7, 18);
+            this.oneForthButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.oneForthButton.Name = "oneForthButton";
-            this.oneForthButton.Size = new System.Drawing.Size(40, 30);
+            this.oneForthButton.Size = new System.Drawing.Size(53, 37);
             this.oneForthButton.TabIndex = 0;
             this.oneForthButton.Text = "0.25";
             this.oneForthButton.UseVisualStyleBackColor = false;
@@ -330,9 +343,10 @@ namespace ControlRoomApplication.Main
             this.editButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.editButton.BackColor = System.Drawing.Color.OrangeRed;
             this.editButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.editButton.Location = new System.Drawing.Point(250, 10);
+            this.editButton.Location = new System.Drawing.Point(333, 12);
+            this.editButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.editButton.Name = "editButton";
-            this.editButton.Size = new System.Drawing.Size(131, 25);
+            this.editButton.Size = new System.Drawing.Size(175, 31);
             this.editButton.TabIndex = 17;
             this.editButton.Text = "Edit Position";
             this.editButton.UseVisualStyleBackColor = false;
@@ -343,10 +357,9 @@ namespace ControlRoomApplication.Main
             this.errorLabel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.errorLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.errorLabel.ForeColor = System.Drawing.Color.Red;
-            this.errorLabel.Location = new System.Drawing.Point(335, 423);
-            this.errorLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.errorLabel.Location = new System.Drawing.Point(447, 521);
             this.errorLabel.Name = "errorLabel";
-            this.errorLabel.Size = new System.Drawing.Size(230, 19);
+            this.errorLabel.Size = new System.Drawing.Size(306, 23);
             this.errorLabel.TabIndex = 18;
             this.errorLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -365,9 +378,11 @@ namespace ControlRoomApplication.Main
             this.overRideGroupbox.Controls.Add(this.TargetRALabel);
             this.overRideGroupbox.Controls.Add(this.TargetDecTextBox);
             this.overRideGroupbox.Controls.Add(this.TargetPositionLabel);
-            this.overRideGroupbox.Location = new System.Drawing.Point(12, 9);
+            this.overRideGroupbox.Location = new System.Drawing.Point(16, 11);
+            this.overRideGroupbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.overRideGroupbox.Name = "overRideGroupbox";
-            this.overRideGroupbox.Size = new System.Drawing.Size(279, 198);
+            this.overRideGroupbox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.overRideGroupbox.Size = new System.Drawing.Size(372, 244);
             this.overRideGroupbox.TabIndex = 19;
             this.overRideGroupbox.TabStop = false;
             this.overRideGroupbox.Text = "Position Information";
@@ -376,30 +391,29 @@ namespace ControlRoomApplication.Main
             // 
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(18, 167);
-            this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label8.Location = new System.Drawing.Point(24, 206);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(121, 13);
+            this.label8.Size = new System.Drawing.Size(159, 17);
             this.label8.TabIndex = 16;
             this.label8.Text = "Radio Telescope Status";
             // 
             // statusTextBox
             // 
-            this.statusTextBox.Location = new System.Drawing.Point(143, 164);
-            this.statusTextBox.Margin = new System.Windows.Forms.Padding(2);
+            this.statusTextBox.Location = new System.Drawing.Point(191, 202);
+            this.statusTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.statusTextBox.Name = "statusTextBox";
             this.statusTextBox.ReadOnly = true;
-            this.statusTextBox.Size = new System.Drawing.Size(102, 20);
+            this.statusTextBox.Size = new System.Drawing.Size(135, 22);
             this.statusTextBox.TabIndex = 15;
             // 
             // ActualDecTextBox
             // 
             this.ActualDecTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.ActualDecTextBox.Location = new System.Drawing.Point(153, 119);
-            this.ActualDecTextBox.Margin = new System.Windows.Forms.Padding(2);
+            this.ActualDecTextBox.Location = new System.Drawing.Point(204, 146);
+            this.ActualDecTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ActualDecTextBox.Name = "ActualDecTextBox";
             this.ActualDecTextBox.ReadOnly = true;
-            this.ActualDecTextBox.Size = new System.Drawing.Size(76, 20);
+            this.ActualDecTextBox.Size = new System.Drawing.Size(100, 22);
             this.ActualDecTextBox.TabIndex = 6;
             // 
             // decIncGroupbox
@@ -410,11 +424,11 @@ namespace ControlRoomApplication.Main
             this.decIncGroupbox.Controls.Add(this.fiveButtonDec);
             this.decIncGroupbox.Controls.Add(this.oneButtonDec);
             this.decIncGroupbox.Controls.Add(this.oneForthButtonDec);
-            this.decIncGroupbox.Location = new System.Drawing.Point(4, 104);
-            this.decIncGroupbox.Margin = new System.Windows.Forms.Padding(2);
+            this.decIncGroupbox.Location = new System.Drawing.Point(5, 128);
+            this.decIncGroupbox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.decIncGroupbox.Name = "decIncGroupbox";
-            this.decIncGroupbox.Padding = new System.Windows.Forms.Padding(2);
-            this.decIncGroupbox.Size = new System.Drawing.Size(188, 56);
+            this.decIncGroupbox.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.decIncGroupbox.Size = new System.Drawing.Size(251, 69);
             this.decIncGroupbox.TabIndex = 20;
             this.decIncGroupbox.TabStop = false;
             this.decIncGroupbox.Text = "Declanation Increment";
@@ -423,10 +437,10 @@ namespace ControlRoomApplication.Main
             // 
             this.tenButtonDec.BackColor = System.Drawing.Color.DarkGray;
             this.tenButtonDec.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.tenButtonDec.Location = new System.Drawing.Point(136, 15);
-            this.tenButtonDec.Margin = new System.Windows.Forms.Padding(2);
+            this.tenButtonDec.Location = new System.Drawing.Point(181, 18);
+            this.tenButtonDec.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tenButtonDec.Name = "tenButtonDec";
-            this.tenButtonDec.Size = new System.Drawing.Size(40, 30);
+            this.tenButtonDec.Size = new System.Drawing.Size(53, 37);
             this.tenButtonDec.TabIndex = 3;
             this.tenButtonDec.Text = "10";
             this.tenButtonDec.UseVisualStyleBackColor = false;
@@ -435,10 +449,10 @@ namespace ControlRoomApplication.Main
             // 
             this.fiveButtonDec.BackColor = System.Drawing.Color.DarkGray;
             this.fiveButtonDec.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.fiveButtonDec.Location = new System.Drawing.Point(93, 15);
-            this.fiveButtonDec.Margin = new System.Windows.Forms.Padding(2);
+            this.fiveButtonDec.Location = new System.Drawing.Point(124, 18);
+            this.fiveButtonDec.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.fiveButtonDec.Name = "fiveButtonDec";
-            this.fiveButtonDec.Size = new System.Drawing.Size(40, 30);
+            this.fiveButtonDec.Size = new System.Drawing.Size(53, 37);
             this.fiveButtonDec.TabIndex = 2;
             this.fiveButtonDec.Text = "5";
             this.fiveButtonDec.UseVisualStyleBackColor = false;
@@ -447,10 +461,10 @@ namespace ControlRoomApplication.Main
             // 
             this.oneButtonDec.BackColor = System.Drawing.Color.DarkGray;
             this.oneButtonDec.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.oneButtonDec.Location = new System.Drawing.Point(49, 15);
-            this.oneButtonDec.Margin = new System.Windows.Forms.Padding(2);
+            this.oneButtonDec.Location = new System.Drawing.Point(65, 18);
+            this.oneButtonDec.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.oneButtonDec.Name = "oneButtonDec";
-            this.oneButtonDec.Size = new System.Drawing.Size(40, 30);
+            this.oneButtonDec.Size = new System.Drawing.Size(53, 37);
             this.oneButtonDec.TabIndex = 1;
             this.oneButtonDec.Text = "1";
             this.oneButtonDec.UseVisualStyleBackColor = false;
@@ -459,10 +473,10 @@ namespace ControlRoomApplication.Main
             // 
             this.oneForthButtonDec.BackColor = System.Drawing.Color.DarkGray;
             this.oneForthButtonDec.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.oneForthButtonDec.Location = new System.Drawing.Point(5, 15);
-            this.oneForthButtonDec.Margin = new System.Windows.Forms.Padding(2);
+            this.oneForthButtonDec.Location = new System.Drawing.Point(7, 18);
+            this.oneForthButtonDec.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.oneForthButtonDec.Name = "oneForthButtonDec";
-            this.oneForthButtonDec.Size = new System.Drawing.Size(40, 30);
+            this.oneForthButtonDec.Size = new System.Drawing.Size(53, 37);
             this.oneForthButtonDec.TabIndex = 0;
             this.oneForthButtonDec.Text = "0.25";
             this.oneForthButtonDec.UseVisualStyleBackColor = false;
@@ -478,9 +492,11 @@ namespace ControlRoomApplication.Main
             this.freeControlGroupbox.Controls.Add(this.RAIncGroupbox);
             this.freeControlGroupbox.Controls.Add(this.editButton);
             this.freeControlGroupbox.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.freeControlGroupbox.Location = new System.Drawing.Point(12, 213);
+            this.freeControlGroupbox.Location = new System.Drawing.Point(16, 262);
+            this.freeControlGroupbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.freeControlGroupbox.Name = "freeControlGroupbox";
-            this.freeControlGroupbox.Size = new System.Drawing.Size(405, 201);
+            this.freeControlGroupbox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.freeControlGroupbox.Size = new System.Drawing.Size(540, 247);
             this.freeControlGroupbox.TabIndex = 22;
             this.freeControlGroupbox.TabStop = false;
             this.freeControlGroupbox.Text = "Edit Target Position";
@@ -501,9 +517,10 @@ namespace ControlRoomApplication.Main
             "Home Telescope",
             "Custom Orientation Movement",
             "Endless Azimuth Rotation"});
-            this.controlScriptsCombo.Location = new System.Drawing.Point(4, 28);
+            this.controlScriptsCombo.Location = new System.Drawing.Point(5, 34);
+            this.controlScriptsCombo.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.controlScriptsCombo.Name = "controlScriptsCombo";
-            this.controlScriptsCombo.Size = new System.Drawing.Size(260, 21);
+            this.controlScriptsCombo.Size = new System.Drawing.Size(345, 24);
             this.controlScriptsCombo.TabIndex = 23;
             this.controlScriptsCombo.SelectedIndexChanged += new System.EventHandler(this.controlScriptsCombo_SelectedIndexChanged);
             // 
@@ -512,11 +529,11 @@ namespace ControlRoomApplication.Main
             this.groupBox4.BackColor = System.Drawing.Color.Gainsboro;
             this.groupBox4.Controls.Add(this.runControlScriptButton);
             this.groupBox4.Controls.Add(this.controlScriptsCombo);
-            this.groupBox4.Location = new System.Drawing.Point(296, 29);
-            this.groupBox4.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox4.Location = new System.Drawing.Point(395, 36);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox4.Size = new System.Drawing.Size(418, 65);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBox4.Size = new System.Drawing.Size(557, 80);
             this.groupBox4.TabIndex = 24;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Control Scripts and Spectra";
@@ -525,10 +542,10 @@ namespace ControlRoomApplication.Main
             // 
             this.runControlScriptButton.BackColor = System.Drawing.Color.DarkGray;
             this.runControlScriptButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.runControlScriptButton.Location = new System.Drawing.Point(288, 16);
-            this.runControlScriptButton.Margin = new System.Windows.Forms.Padding(2);
+            this.runControlScriptButton.Location = new System.Drawing.Point(384, 20);
+            this.runControlScriptButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.runControlScriptButton.Name = "runControlScriptButton";
-            this.runControlScriptButton.Size = new System.Drawing.Size(126, 33);
+            this.runControlScriptButton.Size = new System.Drawing.Size(168, 41);
             this.runControlScriptButton.TabIndex = 24;
             this.runControlScriptButton.Text = "Run Script";
             this.runControlScriptButton.UseVisualStyleBackColor = false;
@@ -551,21 +568,22 @@ namespace ControlRoomApplication.Main
             this.manualGroupBox.Controls.Add(this.plusElaButton);
             this.manualGroupBox.Controls.Add(this.subElaButton);
             this.manualGroupBox.Controls.Add(this.cwAzJogButton);
-            this.manualGroupBox.Location = new System.Drawing.Point(423, 213);
-            this.manualGroupBox.Margin = new System.Windows.Forms.Padding(2);
+            this.manualGroupBox.Location = new System.Drawing.Point(564, 262);
+            this.manualGroupBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.manualGroupBox.Name = "manualGroupBox";
-            this.manualGroupBox.Padding = new System.Windows.Forms.Padding(2);
-            this.manualGroupBox.Size = new System.Drawing.Size(279, 201);
+            this.manualGroupBox.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.manualGroupBox.Size = new System.Drawing.Size(372, 247);
             this.manualGroupBox.TabIndex = 25;
             this.manualGroupBox.TabStop = false;
             this.manualGroupBox.Text = "Manual Control";
             // 
             // speedTrackBar
             // 
-            this.speedTrackBar.Location = new System.Drawing.Point(108, 145);
+            this.speedTrackBar.Location = new System.Drawing.Point(144, 178);
+            this.speedTrackBar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.speedTrackBar.Maximum = 20;
             this.speedTrackBar.Name = "speedTrackBar";
-            this.speedTrackBar.Size = new System.Drawing.Size(150, 45);
+            this.speedTrackBar.Size = new System.Drawing.Size(200, 56);
             this.speedTrackBar.SmallChange = 3;
             this.speedTrackBar.TabIndex = 20;
             this.speedTrackBar.Scroll += new System.EventHandler(this.speedTrackBar_Scroll);
@@ -574,10 +592,9 @@ namespace ControlRoomApplication.Main
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(105, 79);
-            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label4.Location = new System.Drawing.Point(140, 97);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(22, 13);
+            this.label4.Size = new System.Drawing.Size(28, 17);
             this.label4.TabIndex = 28;
             this.label4.Text = "0.0";
             // 
@@ -585,20 +602,18 @@ namespace ControlRoomApplication.Main
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(105, 60);
-            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label5.Location = new System.Drawing.Point(140, 74);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(22, 13);
+            this.label5.Size = new System.Drawing.Size(28, 17);
             this.label5.TabIndex = 27;
             this.label5.Text = "0.0";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 147);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label3.Location = new System.Drawing.Point(8, 181);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(76, 13);
+            this.label3.Size = new System.Drawing.Size(100, 17);
             this.label3.TabIndex = 26;
             this.label3.Text = "Speed (RPMs)";
             // 
@@ -607,10 +622,10 @@ namespace ControlRoomApplication.Main
             this.manualControlButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.manualControlButton.BackColor = System.Drawing.Color.OrangeRed;
             this.manualControlButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.manualControlButton.Location = new System.Drawing.Point(15, 17);
-            this.manualControlButton.Margin = new System.Windows.Forms.Padding(2);
+            this.manualControlButton.Location = new System.Drawing.Point(20, 21);
+            this.manualControlButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.manualControlButton.Name = "manualControlButton";
-            this.manualControlButton.Size = new System.Drawing.Size(150, 28);
+            this.manualControlButton.Size = new System.Drawing.Size(200, 34);
             this.manualControlButton.TabIndex = 25;
             this.manualControlButton.Text = "Activate Manual Control";
             this.manualControlButton.UseVisualStyleBackColor = false;
@@ -620,10 +635,10 @@ namespace ControlRoomApplication.Main
             // 
             this.immediateRadioButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.immediateRadioButton.AutoSize = true;
-            this.immediateRadioButton.Location = new System.Drawing.Point(9, 123);
-            this.immediateRadioButton.Margin = new System.Windows.Forms.Padding(2);
+            this.immediateRadioButton.Location = new System.Drawing.Point(12, 151);
+            this.immediateRadioButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.immediateRadioButton.Name = "immediateRadioButton";
-            this.immediateRadioButton.Size = new System.Drawing.Size(98, 17);
+            this.immediateRadioButton.Size = new System.Drawing.Size(126, 21);
             this.immediateRadioButton.TabIndex = 24;
             this.immediateRadioButton.Text = "Immediate Stop";
             this.immediateRadioButton.UseVisualStyleBackColor = true;
@@ -633,10 +648,10 @@ namespace ControlRoomApplication.Main
             this.ControlledButtonRadio.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.ControlledButtonRadio.AutoSize = true;
             this.ControlledButtonRadio.Checked = true;
-            this.ControlledButtonRadio.Location = new System.Drawing.Point(9, 104);
-            this.ControlledButtonRadio.Margin = new System.Windows.Forms.Padding(2);
+            this.ControlledButtonRadio.Location = new System.Drawing.Point(12, 128);
+            this.ControlledButtonRadio.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ControlledButtonRadio.Name = "ControlledButtonRadio";
-            this.ControlledButtonRadio.Size = new System.Drawing.Size(97, 17);
+            this.ControlledButtonRadio.Size = new System.Drawing.Size(126, 21);
             this.ControlledButtonRadio.TabIndex = 23;
             this.ControlledButtonRadio.TabStop = true;
             this.ControlledButtonRadio.Text = "Controlled Stop";
@@ -645,29 +660,31 @@ namespace ControlRoomApplication.Main
             // speedTextBox
             // 
             this.speedTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.speedTextBox.Location = new System.Drawing.Point(9, 162);
-            this.speedTextBox.Margin = new System.Windows.Forms.Padding(2);
+            this.speedTextBox.Location = new System.Drawing.Point(12, 199);
+            this.speedTextBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.speedTextBox.Name = "speedTextBox";
             this.speedTextBox.ReadOnly = true;
-            this.speedTextBox.Size = new System.Drawing.Size(69, 20);
+            this.speedTextBox.Size = new System.Drawing.Size(91, 22);
             this.speedTextBox.TabIndex = 10;
             this.speedTextBox.TextChanged += new System.EventHandler(this.speedTextBox_TextChanged);
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 80);
+            this.label2.Location = new System.Drawing.Point(8, 98);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(87, 13);
+            this.label2.Size = new System.Drawing.Size(117, 17);
             this.label2.TabIndex = 9;
             this.label2.Text = "Current Azimuth: ";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 60);
+            this.label1.Location = new System.Drawing.Point(8, 74);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(94, 13);
+            this.label1.Size = new System.Drawing.Size(125, 17);
             this.label1.TabIndex = 8;
             this.label1.Text = "Current Elevation: ";
             // 
@@ -676,10 +693,10 @@ namespace ControlRoomApplication.Main
             this.ccwAzJogButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.ccwAzJogButton.BackColor = System.Drawing.Color.DarkGray;
             this.ccwAzJogButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.ccwAzJogButton.Location = new System.Drawing.Point(150, 54);
-            this.ccwAzJogButton.Margin = new System.Windows.Forms.Padding(2);
+            this.ccwAzJogButton.Location = new System.Drawing.Point(200, 66);
+            this.ccwAzJogButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ccwAzJogButton.Name = "ccwAzJogButton";
-            this.ccwAzJogButton.Size = new System.Drawing.Size(40, 40);
+            this.ccwAzJogButton.Size = new System.Drawing.Size(53, 49);
             this.ccwAzJogButton.TabIndex = 6;
             this.ccwAzJogButton.Text = "CCW Jog";
             this.ccwAzJogButton.UseVisualStyleBackColor = false;
@@ -691,10 +708,10 @@ namespace ControlRoomApplication.Main
             this.plusElaButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.plusElaButton.BackColor = System.Drawing.Color.DarkGray;
             this.plusElaButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.plusElaButton.Location = new System.Drawing.Point(190, 10);
-            this.plusElaButton.Margin = new System.Windows.Forms.Padding(2);
+            this.plusElaButton.Location = new System.Drawing.Point(253, 12);
+            this.plusElaButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.plusElaButton.Name = "plusElaButton";
-            this.plusElaButton.Size = new System.Drawing.Size(40, 40);
+            this.plusElaButton.Size = new System.Drawing.Size(53, 49);
             this.plusElaButton.TabIndex = 4;
             this.plusElaButton.Text = "+ Ela";
             this.plusElaButton.UseVisualStyleBackColor = false;
@@ -706,10 +723,10 @@ namespace ControlRoomApplication.Main
             this.subElaButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.subElaButton.BackColor = System.Drawing.Color.DarkGray;
             this.subElaButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.subElaButton.Location = new System.Drawing.Point(190, 100);
-            this.subElaButton.Margin = new System.Windows.Forms.Padding(2);
+            this.subElaButton.Location = new System.Drawing.Point(253, 123);
+            this.subElaButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.subElaButton.Name = "subElaButton";
-            this.subElaButton.Size = new System.Drawing.Size(40, 40);
+            this.subElaButton.Size = new System.Drawing.Size(53, 49);
             this.subElaButton.TabIndex = 5;
             this.subElaButton.Text = "- Ela";
             this.subElaButton.UseVisualStyleBackColor = false;
@@ -721,10 +738,10 @@ namespace ControlRoomApplication.Main
             this.cwAzJogButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.cwAzJogButton.BackColor = System.Drawing.Color.DarkGray;
             this.cwAzJogButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.cwAzJogButton.Location = new System.Drawing.Point(230, 54);
-            this.cwAzJogButton.Margin = new System.Windows.Forms.Padding(2);
+            this.cwAzJogButton.Location = new System.Drawing.Point(307, 66);
+            this.cwAzJogButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cwAzJogButton.Name = "cwAzJogButton";
-            this.cwAzJogButton.Size = new System.Drawing.Size(40, 40);
+            this.cwAzJogButton.Size = new System.Drawing.Size(53, 49);
             this.cwAzJogButton.TabIndex = 7;
             this.cwAzJogButton.Text = "CW Jog";
             this.cwAzJogButton.UseVisualStyleBackColor = false;
@@ -737,10 +754,10 @@ namespace ControlRoomApplication.Main
             this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button1.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.button1.Location = new System.Drawing.Point(692, 2);
-            this.button1.Margin = new System.Windows.Forms.Padding(2);
+            this.button1.Location = new System.Drawing.Point(923, 2);
+            this.button1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(22, 23);
+            this.button1.Size = new System.Drawing.Size(29, 28);
             this.button1.TabIndex = 26;
             this.button1.Text = "?";
             this.button1.UseVisualStyleBackColor = false;
@@ -763,11 +780,11 @@ namespace ControlRoomApplication.Main
             this.spectraCyberGroupBox.Controls.Add(this.label9);
             this.spectraCyberGroupBox.Controls.Add(this.offsetVoltage);
             this.spectraCyberGroupBox.Controls.Add(this.scanTypeComboBox);
-            this.spectraCyberGroupBox.Location = new System.Drawing.Point(296, 111);
-            this.spectraCyberGroupBox.Margin = new System.Windows.Forms.Padding(2);
+            this.spectraCyberGroupBox.Location = new System.Drawing.Point(395, 137);
+            this.spectraCyberGroupBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.spectraCyberGroupBox.Name = "spectraCyberGroupBox";
-            this.spectraCyberGroupBox.Padding = new System.Windows.Forms.Padding(2);
-            this.spectraCyberGroupBox.Size = new System.Drawing.Size(418, 84);
+            this.spectraCyberGroupBox.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.spectraCyberGroupBox.Size = new System.Drawing.Size(557, 103);
             this.spectraCyberGroupBox.TabIndex = 29;
             this.spectraCyberGroupBox.TabStop = false;
             this.spectraCyberGroupBox.Text = "Spectra Cyber";
@@ -776,10 +793,9 @@ namespace ControlRoomApplication.Main
             // 
             this.label12.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(133, 43);
-            this.label12.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label12.Location = new System.Drawing.Point(177, 53);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(74, 13);
+            this.label12.Size = new System.Drawing.Size(98, 17);
             this.label12.TabIndex = 26;
             this.label12.Text = "Offset Voltage";
             // 
@@ -793,11 +809,11 @@ namespace ControlRoomApplication.Main
             "0.3",
             "0.5(S)/1.00(C) ",
             "1.00(S)/10.00(C)"});
-            this.integrationStepCombo.Location = new System.Drawing.Point(215, 56);
-            this.integrationStepCombo.Margin = new System.Windows.Forms.Padding(2);
+            this.integrationStepCombo.Location = new System.Drawing.Point(287, 69);
+            this.integrationStepCombo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.integrationStepCombo.MaxDropDownItems = 6;
             this.integrationStepCombo.Name = "integrationStepCombo";
-            this.integrationStepCombo.Size = new System.Drawing.Size(79, 21);
+            this.integrationStepCombo.Size = new System.Drawing.Size(104, 24);
             this.integrationStepCombo.TabIndex = 44;
             this.integrationStepCombo.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
             // 
@@ -805,20 +821,19 @@ namespace ControlRoomApplication.Main
             // 
             this.label10.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(0, 41);
-            this.label10.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label10.Location = new System.Drawing.Point(0, 50);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(66, 13);
+            this.label10.Size = new System.Drawing.Size(88, 17);
             this.label10.TabIndex = 43;
             this.label10.Text = "DCGain (dB)";
             // 
             // IFGainVal
             // 
             this.IFGainVal.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.IFGainVal.Location = new System.Drawing.Point(77, 57);
-            this.IFGainVal.Margin = new System.Windows.Forms.Padding(2);
+            this.IFGainVal.Location = new System.Drawing.Point(103, 70);
+            this.IFGainVal.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.IFGainVal.Name = "IFGainVal";
-            this.IFGainVal.Size = new System.Drawing.Size(44, 20);
+            this.IFGainVal.Size = new System.Drawing.Size(57, 22);
             this.IFGainVal.TabIndex = 42;
             this.IFGainVal.TextChanged += new System.EventHandler(this.IFGainVal_TextChanged);
             // 
@@ -826,10 +841,9 @@ namespace ControlRoomApplication.Main
             // 
             this.lblIFGain.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.lblIFGain.AutoSize = true;
-            this.lblIFGain.Location = new System.Drawing.Point(74, 43);
-            this.lblIFGain.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblIFGain.Location = new System.Drawing.Point(99, 53);
             this.lblIFGain.Name = "lblIFGain";
-            this.lblIFGain.Size = new System.Drawing.Size(60, 13);
+            this.lblIFGain.Size = new System.Drawing.Size(80, 17);
             this.lblIFGain.TabIndex = 41;
             this.lblIFGain.Text = "IFGain (dB)";
             // 
@@ -837,10 +851,10 @@ namespace ControlRoomApplication.Main
             // 
             this.finalizeSettingsButton.BackColor = System.Drawing.Color.DarkGray;
             this.finalizeSettingsButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.finalizeSettingsButton.Location = new System.Drawing.Point(309, 10);
-            this.finalizeSettingsButton.Margin = new System.Windows.Forms.Padding(2);
+            this.finalizeSettingsButton.Location = new System.Drawing.Point(412, 12);
+            this.finalizeSettingsButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.finalizeSettingsButton.Name = "finalizeSettingsButton";
-            this.finalizeSettingsButton.Size = new System.Drawing.Size(97, 27);
+            this.finalizeSettingsButton.Size = new System.Drawing.Size(129, 33);
             this.finalizeSettingsButton.TabIndex = 40;
             this.finalizeSettingsButton.Text = "Finalize Settings";
             this.finalizeSettingsButton.UseVisualStyleBackColor = false;
@@ -859,11 +873,11 @@ namespace ControlRoomApplication.Main
             "X20",
             "X50",
             "X60"});
-            this.DCGain.Location = new System.Drawing.Point(4, 56);
-            this.DCGain.Margin = new System.Windows.Forms.Padding(2);
+            this.DCGain.Location = new System.Drawing.Point(5, 69);
+            this.DCGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.DCGain.MaxDropDownItems = 6;
             this.DCGain.Name = "DCGain";
-            this.DCGain.Size = new System.Drawing.Size(57, 21);
+            this.DCGain.Size = new System.Drawing.Size(75, 24);
             this.DCGain.TabIndex = 39;
             this.DCGain.SelectedIndexChanged += new System.EventHandler(this.DCGain_SelectedIndexChanged);
             // 
@@ -872,10 +886,10 @@ namespace ControlRoomApplication.Main
             this.stopScanButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.stopScanButton.BackColor = System.Drawing.Color.OrangeRed;
             this.stopScanButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.stopScanButton.Location = new System.Drawing.Point(361, 44);
-            this.stopScanButton.Margin = new System.Windows.Forms.Padding(2);
+            this.stopScanButton.Location = new System.Drawing.Point(481, 54);
+            this.stopScanButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.stopScanButton.Name = "stopScanButton";
-            this.stopScanButton.Size = new System.Drawing.Size(45, 36);
+            this.stopScanButton.Size = new System.Drawing.Size(60, 44);
             this.stopScanButton.TabIndex = 37;
             this.stopScanButton.Text = "Stop Scan";
             this.stopScanButton.UseVisualStyleBackColor = false;
@@ -886,10 +900,10 @@ namespace ControlRoomApplication.Main
             this.startScanButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.startScanButton.BackColor = System.Drawing.Color.LimeGreen;
             this.startScanButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.startScanButton.Location = new System.Drawing.Point(309, 44);
-            this.startScanButton.Margin = new System.Windows.Forms.Padding(2);
+            this.startScanButton.Location = new System.Drawing.Point(412, 54);
+            this.startScanButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.startScanButton.Name = "startScanButton";
-            this.startScanButton.Size = new System.Drawing.Size(48, 36);
+            this.startScanButton.Size = new System.Drawing.Size(64, 44);
             this.startScanButton.TabIndex = 36;
             this.startScanButton.Text = "Start Scan";
             this.startScanButton.UseVisualStyleBackColor = false;
@@ -898,10 +912,10 @@ namespace ControlRoomApplication.Main
             // frequency
             // 
             this.frequency.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.frequency.Location = new System.Drawing.Point(158, 18);
-            this.frequency.Margin = new System.Windows.Forms.Padding(2);
+            this.frequency.Location = new System.Drawing.Point(211, 22);
+            this.frequency.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.frequency.Name = "frequency";
-            this.frequency.Size = new System.Drawing.Size(76, 20);
+            this.frequency.Size = new System.Drawing.Size(100, 22);
             this.frequency.TabIndex = 35;
             this.frequency.TextChanged += new System.EventHandler(this.frequency_TextChanged);
             // 
@@ -909,10 +923,9 @@ namespace ControlRoomApplication.Main
             // 
             this.lblFrequency.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.lblFrequency.AutoSize = true;
-            this.lblFrequency.Location = new System.Drawing.Point(155, 0);
-            this.lblFrequency.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblFrequency.Location = new System.Drawing.Point(207, 0);
             this.lblFrequency.Name = "lblFrequency";
-            this.lblFrequency.Size = new System.Drawing.Size(79, 13);
+            this.lblFrequency.Size = new System.Drawing.Size(106, 17);
             this.lblFrequency.TabIndex = 34;
             this.lblFrequency.Text = "Frequency (Hz)";
             // 
@@ -920,20 +933,19 @@ namespace ControlRoomApplication.Main
             // 
             this.label9.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(212, 44);
-            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label9.Location = new System.Drawing.Point(283, 54);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(82, 13);
+            this.label9.Size = new System.Drawing.Size(108, 17);
             this.label9.TabIndex = 32;
             this.label9.Text = "Integration Step";
             // 
             // offsetVoltage
             // 
             this.offsetVoltage.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.offsetVoltage.Location = new System.Drawing.Point(136, 57);
-            this.offsetVoltage.Margin = new System.Windows.Forms.Padding(2);
+            this.offsetVoltage.Location = new System.Drawing.Point(181, 70);
+            this.offsetVoltage.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.offsetVoltage.Name = "offsetVoltage";
-            this.offsetVoltage.Size = new System.Drawing.Size(44, 20);
+            this.offsetVoltage.Size = new System.Drawing.Size(57, 22);
             this.offsetVoltage.TabIndex = 27;
             this.offsetVoltage.TextChanged += new System.EventHandler(this.offsetVoltage_TextChanged);
             // 
@@ -946,20 +958,20 @@ namespace ControlRoomApplication.Main
             "Scan Type",
             "Continuum",
             "Spectral"});
-            this.scanTypeComboBox.Location = new System.Drawing.Point(4, 18);
-            this.scanTypeComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.scanTypeComboBox.Location = new System.Drawing.Point(5, 22);
+            this.scanTypeComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.scanTypeComboBox.MaxDropDownItems = 2;
             this.scanTypeComboBox.Name = "scanTypeComboBox";
-            this.scanTypeComboBox.Size = new System.Drawing.Size(83, 21);
+            this.scanTypeComboBox.Size = new System.Drawing.Size(109, 24);
             this.scanTypeComboBox.TabIndex = 25;
             this.scanTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.scanTypeComboBox_SelectedIndexChanged);
             // 
             // FreeControlForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Gray;
-            this.ClientSize = new System.Drawing.Size(725, 439);
+            this.ClientSize = new System.Drawing.Size(967, 540);
             this.Controls.Add(this.spectraCyberGroupBox);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.manualGroupBox);
@@ -968,9 +980,11 @@ namespace ControlRoomApplication.Main
             this.Controls.Add(this.overRideGroupbox);
             this.Controls.Add(this.errorLabel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MinimumSize = new System.Drawing.Size(600, 478);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.MinimumSize = new System.Drawing.Size(794, 577);
             this.Name = "FreeControlForm";
             this.Text = "Control Form";
+            this.Load += new System.EventHandler(this.FreeControlForm_Load);
             this.RAIncGroupbox.ResumeLayout(false);
             this.overRideGroupbox.ResumeLayout(false);
             this.overRideGroupbox.PerformLayout();


### PR DESCRIPTION
A tool-tip is now displayed if the weather station could not be created on the specified port.
The "create production weather station" button is now removed (weather station will be created on start of telescope instead).