### PR TITLE
Clos

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.cs
@@ -209,7 +209,13 @@ namespace ControlRoomApplication.Main
             DatabaseOperations.UpdateAppointment(CurrentAppointment);
 
             var threads = controlRoom.RTControllerManagementThreads.Where<RadioTelescopeControllerManagementThread>(t => t.RTController == rtController).ToList<RadioTelescopeControllerManagementThread>();
-            threads[0].EndAppointment();
+
+            //Done in a new thread so the UI does not freeze while waiting for the move to finish
+            new Thread(() =>
+            {
+                threads[0].EndAppointment();
+            }).Start();
+            
 
             timer1.Enabled = false;
         }
@@ -1078,6 +1084,11 @@ namespace ControlRoomApplication.Main
         }
 
         private void speedTextBox_TextChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        private void FreeControlForm_Load(object sender, EventArgs e)
         {
 
         }

--- a/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/RTControlForm.designer.cs
@@ -971,6 +971,7 @@ namespace ControlRoomApplication.Main
             this.MinimumSize = new System.Drawing.Size(600, 478);
             this.Name = "FreeControlForm";
             this.Text = "Control Form";
+            this.Load += new System.EventHandler(this.FreeControlForm_Load);
             this.RAIncGroupbox.ResumeLayout(false);
             this.overRideGroupbox.ResumeLayout(false);
             this.overRideGroupbox.PerformLayout();


### PR DESCRIPTION
On closing the RT control form, the call to EndAppointment() is now done in a separate thread so the UI does not freeze