### PR TITLE
Readd a Thread.Sleep to MCUManager::MovementMonitor

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/MCUManager/MCUManager.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/MCUManager/MCUManager.cs
@@ -866,6 +866,7 @@ namespace ControlRoomApplication.Controllers {
             
             while (!command.timeout.IsCancellationRequested && !MovementInterruptFlag && CheckMCUErrors().Count == 0 && result == MovementResult.None)
             {
+                Thread.Sleep(100);
 
                 // Anything but homing...
                 if (!homing) completed = MovementCompleted();


### PR DESCRIPTION
For unknown reasons, https://github.com/YCPRadioTelescope/YCP-RT-ControlRoom/commit/82c39fec4c93288ad087d83168e0bda6a9dbc43f broke scripts when run on the simulation. Scripts would begin to execute, but shortly afterward the simulation would receive a controlled stop from the control room. While most of the time this would occur, on rare occasions the simulation wouldn't receive a controlled stop.

Readding this Thread.Sleep(100) that was removed in the referenced commit seemingly fixes the issue.