### PR TITLE
Test add appointment fix issue469

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
@@ -163,10 +163,9 @@ namespace ControlRoomApplication.Database
                                                         .Include(t => t.Orientation)
                                                         .Include(t => t.SpectraCyberConfig)
                                                         .Include(t => t.User)
-                                                        .OrderBy(t => t.Id)
                                                         .ToList<Appointment>();
 
-                    appts = appoints.Where(x => x.telescope_id == radioTelescopeId).ToList();
+                    appts = appoints.Where(x => x.telescope_id == radioTelescopeId).OrderBy(x => x.Id).ToList();
 
                     // Add coordinates to the appointment
                     var coordsForAppt = Context.Coordinates.ToList<Coordinate>();

--- a/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Database/Operations/DatabaseOperations.cs
@@ -163,6 +163,7 @@ namespace ControlRoomApplication.Database
                                                         .Include(t => t.Orientation)
                                                         .Include(t => t.SpectraCyberConfig)
                                                         .Include(t => t.User)
+                                                        .OrderBy(t => t.Id)
                                                         .ToList<Appointment>();
 
                     appts = appoints.Where(x => x.telescope_id == radioTelescopeId).ToList();


### PR DESCRIPTION
If found that `TestAddAppointment` was failing was that the appointments retrieved from the database were not in order by insertion, which the test expected. I believe that the database was returning whichever was faster, which is why the test would sometimes fail and sometimes pass. Now, the retrieved appointments are ordered by ID before being returned in the `GetListOfAppointmentsForRadioTelescope()` method.