### PR TITLE
Fixes to Spectra Cyber Online Status / Connection and CR Shutdown 

### DIFF
--- a/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/PLCCommunication/PLCDrivers/ProductionPLCDriver.cs
@@ -436,9 +436,19 @@ namespace ControlRoomApplication.Controllers
         }
 
         private bool Int_to_bool(int val) {
+            /*
             if (val == 0) {
                 return false;
             } else { return true; }
+            */
+
+            try
+            {
+                return Convert.ToBoolean(val);
+            } catch (Exception ex)
+            {
+                return false;
+            }
         }
 
 

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SpectraCyberControllers/AbstractSpectraCyberController.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SpectraCyberControllers/AbstractSpectraCyberController.cs
@@ -474,7 +474,7 @@ namespace ControlRoomApplication.Controllers
             }
 
             return new SpectraCyberRequest(
-                SpectraCyberCommandTypeEnum.DATA_REQUEST,
+                SpectraCyberCommandTypeEnum.GENERAL_COMMUNICATION,
                 commandString,
                 waitForReply,
                 numChars

--- a/ControlRoomApplication/ControlRoomApplication/Controllers/SpectraCyberControllers/SpectraCyberController.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Controllers/SpectraCyberControllers/SpectraCyberController.cs
@@ -207,6 +207,7 @@ namespace ControlRoomApplication.Controllers
                     {
                         // Something went wrong, return the response
                         SerialCommsFailed = true;
+                        response.Valid = false;
                         return;
                     }
 

--- a/ControlRoomApplication/ControlRoomApplication/Entities/HeartbeatInterface/HeartbeatInterface.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Entities/HeartbeatInterface/HeartbeatInterface.cs
@@ -62,6 +62,8 @@ namespace ControlRoomApplication.Entities
             double MillisecondsSinceLastCheckIn = (DateTime.UtcNow - LastCheckedIn).TotalMilliseconds;
             ReleaseControl();
 
+            LastCheckedIn = DateTime.UtcNow;
+
             return MillisecondsSinceLastCheckIn <= HeartbeatConstants.MAXIMUM_ALLOWABLE_DIFFERENCE_IN_LAST_HEARD_MS;
         }
 

--- a/ControlRoomApplication/ControlRoomApplication/Entities/HeartbeatInterface/HeartbeatInterface.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Entities/HeartbeatInterface/HeartbeatInterface.cs
@@ -64,7 +64,9 @@ namespace ControlRoomApplication.Entities
 
             LastCheckedIn = DateTime.UtcNow;
 
-            return MillisecondsSinceLastCheckIn <= HeartbeatConstants.MAXIMUM_ALLOWABLE_DIFFERENCE_IN_LAST_HEARD_MS;
+            bool alive = MillisecondsSinceLastCheckIn <= HeartbeatConstants.MAXIMUM_ALLOWABLE_DIFFERENCE_IN_LAST_HEARD_MS;
+
+            return alive;
         }
 
         public void BringDownDueToMiscommunication()

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
@@ -100,6 +100,9 @@ namespace ControlRoomApplication.GUI
 
         private int rtId;
 
+        bool testForSC = false;
+        int testForSCCounter = 0; 
+
         private Acceleration[] azOld;
         private Acceleration[] elOld;
         private Acceleration[] cbOld;
@@ -234,12 +237,19 @@ namespace ControlRoomApplication.GUI
         /// Gets and displays the current statuses of the hardware components for the specified configuration.
         /// </summary>
         private void GetHardwareStatuses() {
-            if (rtController.RadioTelescope.SpectraCyberController.IsConsideredAlive()) {
+            if (!testForSC/*rtController.RadioTelescope.SpectraCyberController.IsConsideredAlive()*/) {
                 statuses[0] = "Online";
+                //testForSC = true; 
+            } else
+            {
+                statuses[0] = "NEW Offline"; 
             }
 
             if (controlRoom.WeatherStation.IsConsideredAlive()) {
                 statuses[1] = "Online";
+            } else
+            {
+                statuses[1] = "NEW Offline"; 
             }
         }
 
@@ -459,6 +469,13 @@ namespace ControlRoomApplication.GUI
             lbGateStat.Text = rtController.RadioTelescope.PLCDriver.plcInput.Gate_Sensor.ToString();
 
             GetHardwareStatuses();
+            dataGridView1.Rows[0].Cells[1].Value = statuses[0];
+            testForSCCounter++;
+            if (testForSCCounter == 30)
+            {
+                testForSCCounter = 0;
+                testForSC = !testForSC; 
+            }
 
             SetCurrentWeatherData();
 

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
@@ -237,7 +237,14 @@ namespace ControlRoomApplication.GUI
         /// Gets and displays the current statuses of the hardware components for the specified configuration.
         /// </summary>
         private void GetHardwareStatuses() {
-            if (rtController.RadioTelescope.SpectraCyberController.IsConsideredAlive()) {
+
+            SpectraCyberRequest req = new SpectraCyberRequest(SpectraCyberCommandTypeEnum.DATA_REQUEST, "Test", true, 4);
+            SpectraCyberResponse resp = new SpectraCyberResponse();
+
+            SpectraCyberController spct = rtController.RadioTelescope.SpectraCyberController; 
+            
+
+            if (rtController.RadioTelescope.SpectraCyberController.TestIfComponentIsAlive()) {
                 statuses[0] = "Online";
                 //testForSC = true; 
             } else

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
@@ -237,7 +237,7 @@ namespace ControlRoomApplication.GUI
         /// Gets and displays the current statuses of the hardware components for the specified configuration.
         /// </summary>
         private void GetHardwareStatuses() {
-            if (!testForSC/*rtController.RadioTelescope.SpectraCyberController.IsConsideredAlive()*/) {
+            if (rtController.RadioTelescope.SpectraCyberController.IsConsideredAlive()) {
                 statuses[0] = "Online";
                 //testForSC = true; 
             } else

--- a/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/DiagnosticsForm.cs
@@ -237,27 +237,43 @@ namespace ControlRoomApplication.GUI
         /// Gets and displays the current statuses of the hardware components for the specified configuration.
         /// </summary>
         private void GetHardwareStatuses() {
+            SpectraCyberResponse resp = rtController.RadioTelescope.SpectraCyberController.DoSpectraCyberScan();
 
-            SpectraCyberRequest req = new SpectraCyberRequest(SpectraCyberCommandTypeEnum.DATA_REQUEST, "Test", true, 4);
-            SpectraCyberResponse resp = new SpectraCyberResponse();
-
-            SpectraCyberController spct = rtController.RadioTelescope.SpectraCyberController; 
-            
-
-            if (rtController.RadioTelescope.SpectraCyberController.TestIfComponentIsAlive()) {
-                statuses[0] = "Online";
-                //testForSC = true; 
-            } else
+            if (resp.Valid)
             {
-                statuses[0] = "NEW Offline"; 
+                statuses[0] = "Online";
+            }
+            else
+            {
+                statuses[0] = "Offline";
+
+                try
+                {
+                    rtController.RadioTelescope.SpectraCyberController.BringDown();
+                    
+                } 
+                catch (Exception ex)
+                {
+                    logger.Info(Utilities.GetTimeStamp() + ": Failed to bring down SpectraCyber COM port");
+                }
+
+                try
+                {
+                    rtController.RadioTelescope.SpectraCyberController.BringUp();
+                }
+                catch (Exception ex)
+                {
+                    logger.Info(Utilities.GetTimeStamp() + ": Failed to bring up SpectraCyber COM port");
+                }
             }
 
             if (controlRoom.WeatherStation.IsConsideredAlive()) {
                 statuses[1] = "Online";
             } else
             {
-                statuses[1] = "NEW Offline"; 
+                statuses[1] = "Offline"; 
             }
+            
         }
 
         public delegate void SetStartTimeTextCallback(string text);

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -714,7 +714,7 @@ namespace ControlRoomApplication.Main
             {
                 loopBackBox.Checked = false;
                 this.txtWSCOMPort.Text = "222"; //default WS COM port # is 221
-                this.txtSpectraPort.Text = "777";
+                this.txtSpectraPort.Text = "8"; // Value used to be 777, but the USB's port is currently set to 8
                 this.txtMcuCOMPort.Text = "502"; //default MCU Port
                 this.txtPLCIP.Text = "192.168.0.50";//default IP address
                 this.txtRemoteListenerCOMPort.Text = "80";

--- a/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
+++ b/ControlRoomApplication/ControlRoomApplication/GUI/MainForm.cs
@@ -53,7 +53,9 @@ namespace ControlRoomApplication.Main
         
         // form
         RTControlFormData formData;
-        
+
+        RadioTelescopeControllerManagementThread ManagementThread; 
+
         enum TempSensorType
         {
             Production,
@@ -360,7 +362,7 @@ namespace ControlRoomApplication.Main
 
                     // Start RT controller's threaded management
                     logger.Info(Utilities.GetTimeStamp() + ": Starting RT controller's threaded management");
-                    RadioTelescopeControllerManagementThread ManagementThread = MainControlRoomController.ControlRoom.RTControllerManagementThreads[MainControlRoomController.ControlRoom.RTControllerManagementThreads.Count - 1];
+                    ManagementThread = MainControlRoomController.ControlRoom.RTControllerManagementThreads[MainControlRoomController.ControlRoom.RTControllerManagementThreads.Count - 1];
 
                     // add telescope to database
                     //DatabaseOperations.AddRadioTelescope(ARadioTelescope);
@@ -430,6 +432,14 @@ namespace ControlRoomApplication.Main
         /// </summary>
         private void button2_Click(object sender, EventArgs e)
         {
+            HandleShutDown(); 
+        }
+
+        /// <summary>
+        /// Handles shut down routine for Control Room App.
+        /// </summary>
+        private void HandleShutDown()
+        {
             logger.Info(Utilities.GetTimeStamp() + ": Shut Down Telescope Button Clicked");
 
             // Loop through the list of telescope controllers and call their respective bring down sequences.
@@ -460,15 +470,7 @@ namespace ControlRoomApplication.Main
 
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
-            for (int i = 0; i < ProgramRTControllerList.Count; i++)
-            {
-                //Turn off Telescope in database
-                ProgramRTControllerList[i].RadioTelescope.online = 0;
-                ProgramRTControllerList[i].RadioTelescope.SensorNetworkServer.EndSensorMonitoringRoutine();
-                DatabaseOperations.UpdateTelescope(ProgramRTControllerList[i].RadioTelescope);
-                ProgramRTControllerList[i].ShutdownRadioTelescope();
-            }
-
+            HandleShutDown();
         }
 
         /// <summary>

--- a/ControlRoomApplication/ControlRoomApplication/Simulators/Hardware/PLC_MCU/Simulation_control_pannel.cs
+++ b/ControlRoomApplication/ControlRoomApplication/Simulators/Hardware/PLC_MCU/Simulation_control_pannel.cs
@@ -351,9 +351,12 @@ namespace ControlRoomApplication.Simulators.Hardware.PLC_MCU {
         }
         
         private ushort BoolToInt(bool i ) {
+            /*
             if(!i) {
                 return 0;
             } else return 1;
+            */
+            return Convert.ToUInt16(i);
         }
 
     }


### PR DESCRIPTION
The Spectra Cyber now properly connects to the CR Application. There were various issues. Namely, we were using the incorrect port number and the means of updating the Diagnostic Form's table of hardware statuses was not functional. The status table updates its online/offline statuses in its own thread as of now. 

The Spectra Cyber can now reconnect to the CR Application if it is disconnected. In addition, a fix was made so that the CR Application closes all threads and forms regardless of if the Shutdown RT button or Close (X) button is clicked. This leads to some Invalid Operation exceptions (likely trying to stop null threads / streams), but it fully stops the program nonetheless. 